### PR TITLE
8309761: Leak class loader constraints

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -89,6 +89,9 @@ class ConstraintSet {                               // copied into hashtable as 
   }
 
   ~ConstraintSet() {
+    while (!_constraints->is_empty()) {
+      delete _constraints->pop();
+    }
     delete _constraints;
   }
 


### PR DESCRIPTION
A clean backport to fix memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309761](https://bugs.openjdk.org/browse/JDK-8309761): Leak class loader constraints (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/6.diff">https://git.openjdk.org/jdk21u/pull/6.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/6#issuecomment-1616797955)