### PR TITLE
8311249: Remove unused MemAllocator::obj_memory_range

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -400,15 +400,6 @@ oop ObjAllocator::initialize(HeapWord* mem) const {
   return finish(mem);
 }
 
-MemRegion ObjArrayAllocator::obj_memory_range(oop obj) const {
-  if (_do_zero) {
-    return MemAllocator::obj_memory_range(obj);
-  }
-  ArrayKlass* array_klass = ArrayKlass::cast(_klass);
-  const size_t hs = arrayOopDesc::header_size(array_klass->element_type());
-  return MemRegion(cast_from_oop<HeapWord*>(obj) + hs, _word_size - hs);
-}
-
 oop ObjArrayAllocator::initialize(HeapWord* mem) const {
   // Set array length before setting the _klass field because a
   // non-null klass field indicates that the object is parsable by

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -78,10 +78,6 @@ protected:
   // back to calling CollectedHeap::mem_allocate().
   HeapWord* mem_allocate(Allocation& allocation) const;
 
-  virtual MemRegion obj_memory_range(oop obj) const {
-    return MemRegion(cast_from_oop<HeapWord*>(obj), _word_size);
-  }
-
 public:
   // Allocate and fully construct the object, and perform various instrumentation. Could safepoint.
   oop allocate() const;
@@ -99,8 +95,6 @@ class ObjArrayAllocator: public MemAllocator {
 protected:
   const int  _length;
   const bool _do_zero;
-
-  virtual MemRegion obj_memory_range(oop obj) const;
 
 public:
   ObjArrayAllocator(Klass* klass, size_t word_size, int length, bool do_zero,


### PR DESCRIPTION
Clean backport to remove dead code, keep the codebases in sync (already backported to 17u), and make life easier for downstreams.

Additional testing:
 - [x] Local macos-aarch64-server-fastdebug build
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311249](https://bugs.openjdk.org/browse/JDK-8311249): Remove unused MemAllocator::obj_memory_range (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/8.diff">https://git.openjdk.org/jdk21u/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/8#issuecomment-1628650329)