### PR TITLE
8309746: Reconfigure check should include make/conf/version-numbers.conf

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -138,7 +138,10 @@ ifeq ($(HAS_SPEC),)
     # The spec files depend on the autoconf source code. This check makes sure
     # the configuration is up to date after changes to configure.
     $(SPECS): $(wildcard $(topdir)/make/autoconf/*) \
-            $(if $(CUSTOM_CONFIG_DIR), $(wildcard $(CUSTOM_CONFIG_DIR)/*))
+            $(if $(CUSTOM_CONFIG_DIR), $(wildcard $(CUSTOM_CONFIG_DIR)/*)) \
+            $(addprefix $(topdir)/make/conf/, version-numbers.conf branding.conf) \
+            $(if $(CUSTOM_CONF_DIR), $(wildcard $(addprefix $(CUSTOM_CONF_DIR)/, \
+                version-numbers.conf branding.conf)))
         ifeq ($(CONF_CHECK), fail)
 	  @echo Error: The configuration is not up to date for \
 	      "'$(lastword $(subst /, , $(dir $@)))'."


### PR DESCRIPTION
Clean backport to improve build system support.

Additional testing:
 - [x] Checking that reconfigure message triggers after touching `make/conf/version-numbers.conf`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309746](https://bugs.openjdk.org/browse/JDK-8309746): Reconfigure check should include make/conf/version-numbers.conf (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/16.diff">https://git.openjdk.org/jdk21u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/16#issuecomment-1651675698)