### PR TITLE
8311026: Some G1 specific tests do not set -XX:+UseG1GC

### DIFF
--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms1g -Xmx1g -Xlog:gc TestJNICriticalStressTest 30 4 4 G1
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC -Xms1g -Xmx1g -Xlog:gc TestJNICriticalStressTest 30 4 4 G1
  */
 
  /*

--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -35,7 +35,7 @@ package gc.g1;
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
- *   -XX:+G1VerifyHeapRegionCodeRoots
+ *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
  *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
  *   -XX:+G1VerifyBitmaps
  *   gc.g1.TestVerificationInConcurrentCycle
@@ -54,7 +54,7 @@ package gc.g1;
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
- *   -XX:+G1VerifyHeapRegionCodeRoots
+ *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
  *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
  *   gc.g1.TestVerificationInConcurrentCycle
  */

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -78,7 +78,7 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 3 3
+ * @run main/othervm -XX:+UseG1GC MemoryTest 3 3
  */
 
 /*


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311026](https://bugs.openjdk.org/browse/JDK-8311026): Some G1 specific tests do not set -XX:+UseG1GC (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/18.diff">https://git.openjdk.org/jdk21u/pull/18.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/18#issuecomment-1651784440)