### PR TITLE
8313081: MonitoringSupport_lock should be unconditionally initialized after 8304074

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -224,9 +224,9 @@ void mutex_init() {
 
     MUTEX_DEFN(MarkStackFreeList_lock        , PaddedMutex  , nosafepoint);
     MUTEX_DEFN(MarkStackChunkList_lock       , PaddedMutex  , nosafepoint);
-
-    MUTEX_DEFN(MonitoringSupport_lock        , PaddedMutex  , service-1);      // used for serviceability monitoring support
   }
+  MUTEX_DEFN(MonitoringSupport_lock          , PaddedMutex  , service-1);        // used for serviceability monitoring support
+
   MUTEX_DEFN(StringDedup_lock                , PaddedMonitor, nosafepoint);
   MUTEX_DEFN(StringDedupIntern_lock          , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(RawMonitor_lock                 , PaddedMutex  , nosafepoint-1);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2116,6 +2116,7 @@ JVM_ENTRY(jlong, jmm_GetTotalThreadAllocatedMemory(JNIEnv *env))
     }
 
     {
+      assert(MonitoringSupport_lock != nullptr, "Must be");
       MutexLocker ml(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
       if (result < high_water_result) {
         // Encountered (2) above, or result wrapped to a negative value. In

--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -22,10 +22,19 @@
  */
 
 /*
- * @test
- * @bug     6173675 8231209 8304074
+ * @test    id=G1
+ * @bug     6173675 8231209 8304074 8313081
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
- * @author  Paul Hohensee
+ * @requires vm.gc.G1
+ * @run main/othervm -XX:+UseG1GC ThreadAllocatedMemory
+ */
+
+/*
+ * @test    id=Serial
+ * @bug     6173675 8231209 8304074 8313081
+ * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
+ * @requires vm.gc.Serial
+ * @run main/othervm -XX:+UseSerialGC ThreadAllocatedMemory
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
Clean backport to fix an issue with 8304074. All management tests pass, including the updated ThreadAllocatedMemory.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313081](https://bugs.openjdk.org/browse/JDK-8313081): MonitoringSupport_lock should be unconditionally initialized after 8304074 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/20.diff">https://git.openjdk.org/jdk21u/pull/20.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/20#issuecomment-1654139255)