### PR TITLE
8312525: New test runtime/os/TestTrimNative.java#trimNative is failing: did not see the expected RSS reduction

### DIFF
--- a/src/hotspot/os/linux/trimCHeapDCmd.cpp
+++ b/src/hotspot/os/linux/trimCHeapDCmd.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/log.hpp"
 #include "runtime/os.inline.hpp"
 #include "trimCHeapDCmd.hpp"
 #include "utilities/debug.hpp"
@@ -42,6 +43,9 @@ void TrimCLibcHeapDCmd::execute(DCmdSource source, TRAPS) {
         const char sign = sc.after < sc.before ? '-' : '+';
         _output->print_cr("RSS+Swap: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
                           PROPERFMTARGS(sc.before), PROPERFMTARGS(sc.after), sign, PROPERFMTARGS(delta));
+        // Also log if native trim log is active
+        log_info(trimnative)("Manual Trim: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
+                             PROPERFMTARGS(sc.before), PROPERFMTARGS(sc.after), sign, PROPERFMTARGS(delta));
       } else {
         _output->print_cr("(no details available).");
       }


### PR DESCRIPTION
Semi-clean follow-up backport to relax the test.

There are no `ProblemList` additions in 21u, so this changeset does not have the relevant hunk.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312525](https://bugs.openjdk.org/browse/JDK-8312525): New test runtime/os/TestTrimNative.java#trimNative is failing: did not see the expected RSS reduction (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [c5794abb](https://git.openjdk.org/jdk21u/pull/26/files/c5794abbfec823c38c8f4216e40f1b297e640a75)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/26.diff">https://git.openjdk.org/jdk21u/pull/26.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/26#issuecomment-1658005693)