### PR TITLE
8309238: jdk/jfr/tool/TestView.java failed with "exitValue = 134"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -289,9 +289,6 @@ public final class ChunkParser {
             if (parserState.isClosed()) {
                 return true;
             }
-            if (chunkHeader.getLastNanos() > filterEnd)  {
-              return true;
-            }
             chunkHeader.refresh();
             if (absoluteChunkEnd != chunkHeader.getEnd()) {
                 return false;


### PR DESCRIPTION
This PR fixes a bug that prevents the streaming parser to hang when an end time has been set for a RecordingStream. This can happen when using the new jcmd JFR.view. For details see https://github.com/openjdk/jdk/pull/14987

Testing: tier1, tier2 + jdk/jdk/jfr

Fix applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8309238](https://bugs.openjdk.org/browse/JDK-8309238) needs maintainer approval

### Error
&nbsp;⚠️ 8309238 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8309238](https://bugs.openjdk.org/browse/JDK-8309238): jdk/jfr/tool/TestView.java failed with "exitValue = 134" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/31.diff">https://git.openjdk.org/jdk21u/pull/31.diff</a>

</details>
