### PR TITLE
8312619: Strange error message when switching over long

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -555,6 +555,10 @@ compiler.err.cannot.assign.not.declared.guard=\
 compiler.err.constant.label.not.compatible=\
     constant label of type {0} is not compatible with switch selector type {1}
 
+# 0: type
+compiler.err.selector.type.not.allowed=\
+    selector type {0} is not allowed
+
 compiler.err.flows.through.to.pattern=\
     illegal fall-through to a pattern
 

--- a/test/langtools/tools/javac/diags/examples/SelectorTypeNotAllowed.java
+++ b/test/langtools/tools/javac/diags/examples/SelectorTypeNotAllowed.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.selector.type.not.allowed
+
+public class SelectorTypeNotAllowed {
+    private void noLong(long sel) {
+        switch (sel) {
+            default -> {}
+        }
+    }
+}

--- a/test/langtools/tools/javac/switchextra/SwitchNoExtraTypes.out
+++ b/test/langtools/tools/javac/switchextra/SwitchNoExtraTypes.out
@@ -1,5 +1,5 @@
-SwitchNoExtraTypes.java:12:18: compiler.err.constant.label.not.compatible: boolean, boolean
-SwitchNoExtraTypes.java:18:18: compiler.err.constant.label.not.compatible: int, long
-SwitchNoExtraTypes.java:24:18: compiler.err.constant.label.not.compatible: int, float
-SwitchNoExtraTypes.java:30:18: compiler.err.constant.label.not.compatible: int, double
+SwitchNoExtraTypes.java:11:16: compiler.err.selector.type.not.allowed: boolean
+SwitchNoExtraTypes.java:17:16: compiler.err.selector.type.not.allowed: long
+SwitchNoExtraTypes.java:23:16: compiler.err.selector.type.not.allowed: float
+SwitchNoExtraTypes.java:29:16: compiler.err.selector.type.not.allowed: double
 4 errors


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cc2a75e1](https://github.com/openjdk/jdk/commit/cc2a75e11c4b5728c547aa764067427fdea8c941) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 26 Jul 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312619](https://bugs.openjdk.org/browse/JDK-8312619): Strange error message when switching over long (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/35.diff">https://git.openjdk.org/jdk21u/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/35#issuecomment-1663379394)