### PR TITLE
8310211: serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java failing

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
@@ -44,7 +44,7 @@ static frame_info expected_virtual_frames[] = {
     {"Lgetstacktr03;", "dummy", "()V"},
     {"Lgetstacktr03;", "chain", "()V"},
     {"Lgetstacktr03$Task;", "run", "()V"},
-    {"Ljava/lang/VirtualThread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
+    {"Ljava/lang/Thread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread;", "run", "(Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread$VThreadContinuation$1;", "run", "()V"},
     {"Ljdk/internal/vm/Continuation;", "enter0", "()V"},


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8310211](https://bugs.openjdk.org/browse/JDK-8310211), commit [16134f44](https://github.com/openjdk/jdk/commit/16134f44221e46f71d91fdba08e30705b0e1f92f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Daniel D. Daugherty on 16 Jun 2023 and was reviewed by Mikael Vidstedt.

It is needed as followup to #22 to fix the failing test.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310211](https://bugs.openjdk.org/browse/JDK-8310211): serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java failing (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/36.diff">https://git.openjdk.org/jdk21u/pull/36.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/36#issuecomment-1663406073)