### PR TITLE
8312984: javac may crash on a record pattern with too few components

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -3480,7 +3480,9 @@ public class Flow {
             for (List<JCPattern> it = record.nested;
                  it.nonEmpty();
                  it = it.tail, i++) {
-                nestedDescriptions[i] = makePatternDescription(types.erasure(componentTypes[i]), it.head);
+                Type componentType = i < componentTypes.length ? componentTypes[i]
+                                                               : syms.errType;
+                nestedDescriptions[i] = makePatternDescription(types.erasure(componentType), it.head);
             }
             return new RecordPattern(record.type, componentTypes, nestedDescriptions);
         } else if (pattern instanceof JCAnyPattern) {

--- a/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
+++ b/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
@@ -1,3 +1,5 @@
 PatternErrorRecovery.java:12:18: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.pattern.switch), 20, 21
+PatternErrorRecovery.java:17:19: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.deconstruction.patterns), 20, 21
+PatternErrorRecovery.java:17:27: compiler.err.illegal.start.of.type
 PatternErrorRecovery.java:11:18: compiler.err.pattern.expected
-2 errors
+4 errors

--- a/test/langtools/tools/javac/patterns/PatternErrorRecovery.java
+++ b/test/langtools/tools/javac/patterns/PatternErrorRecovery.java
@@ -1,8 +1,8 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8268320
+ * @bug 8268320 8312984
  * @summary Verify user-friendly errors are reported for ill-formed pattern.
- * @compile/fail/ref=PatternErrorRecovery.out -XDrawDiagnostics -XDshould-stop.at=FLOW PatternErrorRecovery.java
+ * @compile/fail/ref=PatternErrorRecovery.out -XDrawDiagnostics -XDshould-stop.at=FLOW -XDdev PatternErrorRecovery.java
  * @compile/fail/ref=PatternErrorRecovery-old.out --release 20 -XDrawDiagnostics -XDshould-stop.at=FLOW PatternErrorRecovery.java
  */
 public class PatternErrorRecovery {
@@ -12,4 +12,12 @@ public class PatternErrorRecovery {
             case Object obj: break;
         }
     }
+    int errorRecoveryNoPattern2(Object o) {
+        return switch(o) {
+            case R(var v, ) -> 1;
+            default -> -1;
+        };
+    }
+
+    record R(String x) {}
 }

--- a/test/langtools/tools/javac/patterns/PatternErrorRecovery.out
+++ b/test/langtools/tools/javac/patterns/PatternErrorRecovery.out
@@ -1,2 +1,4 @@
+PatternErrorRecovery.java:17:27: compiler.err.illegal.start.of.type
 PatternErrorRecovery.java:11:18: compiler.err.pattern.expected
-1 error
+PatternErrorRecovery.java:17:18: compiler.err.incorrect.number.of.nested.patterns: java.lang.String, java.lang.String,<any>
+3 errors


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c3860917](https://github.com/openjdk/jdk/commit/c3860917346fb53ed3d23f11d112b58b8cd8448a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 3 Aug 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312984](https://bugs.openjdk.org/browse/JDK-8312984): javac may crash on a record pattern with too few components (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/38.diff">https://git.openjdk.org/jdk21u/pull/38.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/38#issuecomment-1663698474)