### PR TITLE
8312909: C1 should not inline through interface calls with non-subtype receiver

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2087,9 +2087,10 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
         assert(singleton != declared_interface, "not a unique implementor");
         cha_monomorphic_target = target->find_monomorphic_target(calling_klass, declared_interface, singleton);
         if (cha_monomorphic_target != nullptr) {
-          if (cha_monomorphic_target->holder() != compilation()->env()->Object_klass()) {
-            ciInstanceKlass* holder = cha_monomorphic_target->holder();
-            ciInstanceKlass* constraint = (holder->is_subtype_of(singleton) ? holder : singleton); // avoid upcasts
+          ciInstanceKlass* holder = cha_monomorphic_target->holder();
+          ciInstanceKlass* constraint = (holder->is_subtype_of(singleton) ? holder : singleton); // avoid upcasts
+          if (holder != compilation()->env()->Object_klass() &&
+              (!type_is_exact || receiver_klass->is_subtype_of(constraint))) {
             actual_recv = declared_interface;
 
             // insert a check it's really the expected class.
@@ -2102,7 +2103,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
 
             dependency_recorder()->assert_unique_implementor(declared_interface, singleton);
           } else {
-            cha_monomorphic_target = nullptr; // subtype check against Object is useless
+            cha_monomorphic_target = nullptr;
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/c1/TestInvokeinterfaceWithBadReceiver.java
+++ b/test/hotspot/jtreg/compiler/c1/TestInvokeinterfaceWithBadReceiver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312909
+ * @summary Test monomorphic interface call to with invalid receiver.
+ * @modules java.base/jdk.internal.vm.annotation
+ * @compile TestInvokeinterfaceWithBadReceiverHelper.jasm
+ * @run main/bootclasspath/othervm -XX:CompileCommand=compileonly,TestInvokeinterfaceWithBadReceiverHelper::test
+ *                                 -Xcomp -XX:TieredStopAtLevel=1 TestInvokeinterfaceWithBadReceiver
+ */
+
+import jdk.internal.vm.annotation.Stable;
+
+interface MyInterface {
+    public String get();
+}
+
+// Single implementor
+class MyClass implements MyInterface {
+    @Stable
+    String field = "42";
+
+    public String get() {
+        return field;
+    }
+}
+
+public class TestInvokeinterfaceWithBadReceiver {
+
+    public static void main(String[] args) {
+        try {
+            TestInvokeinterfaceWithBadReceiverHelper.test(new MyClass());
+            throw new RuntimeException("No IncompatibleClassChangeError thrown!");
+        } catch (IncompatibleClassChangeError e) {
+            // Expected
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c1/TestInvokeinterfaceWithBadReceiverHelper.jasm
+++ b/test/hotspot/jtreg/compiler/c1/TestInvokeinterfaceWithBadReceiverHelper.jasm
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class TestInvokeinterfaceWithBadReceiverHelper
+	version 51:0
+{
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+
+  public static Method test:"(LMyInterface;)Ljava/lang/String;"
+	stack 1 locals 2
+  {
+		ldc	String "42";
+		invokeinterface	InterfaceMethod MyInterface.get:"()Ljava/lang/String;",  1;
+		areturn;
+  }
+  
+} // end Class TestInvokeinterfaceWithBadReceiverHelper


### PR DESCRIPTION
Backport of [JDK-8312909](https://bugs.openjdk.java.net/browse/JDK-8312909). Applies cleanly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312909](https://bugs.openjdk.org/browse/JDK-8312909): C1 should not inline through interface calls with non-subtype receiver (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/40.diff">https://git.openjdk.org/jdk21u/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/40#issuecomment-1665369170)