### PR TITLE
8311926: java/lang/ScopedValue/StressStackOverflow.java takes 9mins in tier1

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -46,7 +46,9 @@ javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x
 
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java#default 8309646 linux-all
+java/lang/ScopedValue/StressStackOverflow.java#default 8309646 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation 8309646 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 8309646 generic-all
 
 javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8311926](https://bugs.openjdk.org/browse/JDK-8311926), commit [7304316a](https://github.com/openjdk/jdk/commit/7304316a8c55a4c0f2a96d1b99ba9e97e49ed7f4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alan Bateman on 12 Jul 2023 and was reviewed by Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311926](https://bugs.openjdk.org/browse/JDK-8311926): java/lang/ScopedValue/StressStackOverflow.java takes 9mins in tier1 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/42.diff">https://git.openjdk.org/jdk21u/pull/42.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/42#issuecomment-1665400370)