### PR TITLE
8308047: java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java timed out and also had jcmd pipe errors

### DIFF
--- a/test/jdk/ProblemList-generational-zgc.txt
+++ b/test/jdk/ProblemList-generational-zgc.txt
@@ -38,5 +38,4 @@ sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java 8307393   generic-all
 sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
 com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
-java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java 8308047 windows-x64
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all

--- a/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
+++ b/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 6602600
- * @run main/othervm -Xmx8m BasicCancelTest
+ * @run main/othervm -Xmx64m BasicCancelTest
  * @summary Check effectiveness of RemoveOnCancelPolicy
  */
 
@@ -76,7 +76,7 @@ public class BasicCancelTest {
         // Needed to avoid OOME
         pool.setRemoveOnCancelPolicy(true);
 
-        final long moreThanYouCanChew = Runtime.getRuntime().freeMemory() / 4;
+        final long moreThanYouCanChew = Runtime.getRuntime().maxMemory() / 32;
         System.out.printf("moreThanYouCanChew=%d%n", moreThanYouCanChew);
 
         Runnable noopTask = new Runnable() { public void run() {}};


### PR DESCRIPTION
The test used a too-small heap for generic testing, and coupled with looking at freeMemory() it led to a less-than-ideal determinism of execution of the test.
It is a clean backport of https://github.com/openjdk/jdk/commit/8c9d091f19760deece8daf3e57add85482b9f2a7 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308047](https://bugs.openjdk.org/browse/JDK-8308047): java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java timed out and also had jcmd pipe errors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/46.diff">https://git.openjdk.org/jdk21u/pull/46.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/46#issuecomment-1670569778)