### PR TITLE
Backport 733bd7244611646e2e07c4560cea96dc5816fd25

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -185,12 +185,24 @@ class CAccessible extends CFRetainedResource implements Accessible {
                         if (newValue != null && !newValue.equals(oldValue)) {
                             valueChanged(ptr);
                         }
+
+                        // Notify native side to handle check box style menuitem
+                        if (parentRole == AccessibleRole.POPUP_MENU && newValue != null
+                                && ((AccessibleState)newValue) == AccessibleState.FOCUSED) {
+                            menuItemSelected(ptr);
+                        }
                     }
 
                     // Do send radio button state changes to native side
                     if (thisRole == AccessibleRole.RADIO_BUTTON) {
                         if (newValue != null && !newValue.equals(oldValue)) {
                             valueChanged(ptr);
+                        }
+
+                        // Notify native side to handle radio button style menuitem
+                        if (parentRole == AccessibleRole.POPUP_MENU && newValue != null
+                            && ((AccessibleState)newValue) == AccessibleState.FOCUSED) {
+                            menuItemSelected(ptr);
                         }
                     }
 


### PR DESCRIPTION
This is backport of https://bugs.openjdk.org/browse/JDK-8311160 to jdk21u.

VoiceOver doesn't announce anything for JRadioButtonMenuItem and JCheckBoxMenuItem when navigated with down arrow key. JRadioButtonMenuItem and JCheckBoxMenuItem are having an accessible role of RadioButton and CheckBox respectively and it is required to notify native side whenever they are selected.

Added the required fix and tested with SwingSet2 application. CI testing is also fine.

Fix can be tested with SwingSet2 application and test instructions are mentioned in [JDK-8311160](https://bugs.openjdk.org/browse/JDK-8311160) description.