### PR TITLE
8311160: [macOS, Accessibility] VoiceOver: No announcements on JRadioButtonMenuItem and JCheckBoxMenuItem

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -185,12 +185,24 @@ class CAccessible extends CFRetainedResource implements Accessible {
                         if (newValue != null && !newValue.equals(oldValue)) {
                             valueChanged(ptr);
                         }
+
+                        // Notify native side to handle check box style menuitem
+                        if (parentRole == AccessibleRole.POPUP_MENU && newValue != null
+                                && ((AccessibleState)newValue) == AccessibleState.FOCUSED) {
+                            menuItemSelected(ptr);
+                        }
                     }
 
                     // Do send radio button state changes to native side
                     if (thisRole == AccessibleRole.RADIO_BUTTON) {
                         if (newValue != null && !newValue.equals(oldValue)) {
                             valueChanged(ptr);
+                        }
+
+                        // Notify native side to handle radio button style menuitem
+                        if (parentRole == AccessibleRole.POPUP_MENU && newValue != null
+                            && ((AccessibleState)newValue) == AccessibleState.FOCUSED) {
+                            menuItemSelected(ptr);
                         }
                     }
 


### PR DESCRIPTION
This is backport of https://bugs.openjdk.org/browse/JDK-8311160 to jdk21u.

VoiceOver doesn't announce anything for JRadioButtonMenuItem and JCheckBoxMenuItem when navigated with down arrow key. JRadioButtonMenuItem and JCheckBoxMenuItem are having an accessible role of RadioButton and CheckBox respectively and it is required to notify native side whenever they are selected.

Added the required fix and tested with SwingSet2 application. CI testing is also fine.

Fix can be tested with SwingSet2 application and test instructions are mentioned in [JDK-8311160](https://bugs.openjdk.org/browse/JDK-8311160) description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311160](https://bugs.openjdk.org/browse/JDK-8311160): [macOS, Accessibility] VoiceOver: No announcements on JRadioButtonMenuItem and JCheckBoxMenuItem (**Bug** - P3)


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/48.diff">https://git.openjdk.org/jdk21u/pull/48.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/48#issuecomment-1670728367)