### PR TITLE
8313676: Amend TestLoadIndexedMismatch test to target intrinsic directly

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestLoadIndexedMismatch.java
+++ b/test/hotspot/jtreg/compiler/c1/TestLoadIndexedMismatch.java
@@ -42,8 +42,8 @@ public class TestLoadIndexedMismatch {
     public static char work() {
         // LoadIndexed (B)
         byte b = ARR[0];
-        // StringUTF16.charAt intrinsic, LoadIndexed (C)
-        char c = Helper.charAt(ARR, 0);
+        // StringUTF16.getChar intrinsic, LoadIndexed (C)
+        char c = Helper.getChar(ARR, 0);
         return c;
     }
 

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -77,6 +77,11 @@ public class Helper {
         return dst;
     }
 
+    @jdk.internal.vm.annotation.ForceInline
+    public static char getChar(byte[] value, int index) {
+        return StringUTF16.getChar(value, index);
+    }
+
     public static void putCharSB(byte[] val, int index, int c) {
         StringUTF16.putCharSB(val, index, c);
     }


### PR DESCRIPTION
Clean backport to improve the test.

Additional testing:
 - [x] macosx-aarch64-server-fastdebug, the affected test is still sensitive to original fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313676](https://bugs.openjdk.org/browse/JDK-8313676): Amend TestLoadIndexedMismatch test to target intrinsic directly (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/49.diff">https://git.openjdk.org/jdk21u/pull/49.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/49#issuecomment-1670980881)