### PR TITLE
8313307: java/util/Formatter/Padding.java fails on some Locales

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -29,6 +29,8 @@
  * @run junit Padding
  */
 
+import java.util.Locale;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -307,7 +309,7 @@ public class Padding {
     @ParameterizedTest
     @MethodSource
     void padding(String expected, String format, Object value) {
-        assertEquals(expected, String.format(format, value));
+        assertEquals(expected, String.format(Locale.US, format, value));
     }
 
 }


### PR DESCRIPTION
Clean backport to fix the test.

Additional testing:
 - [x] Affected test fails without the fix, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313307](https://bugs.openjdk.org/browse/JDK-8313307): java/util/Formatter/Padding.java fails on some Locales (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/51.diff">https://git.openjdk.org/jdk21u/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/51#issuecomment-1673383666)