### PR TITLE
8312127: FileDescriptor.sync should temporarily increase parallelism

### DIFF
--- a/src/java.base/share/classes/java/io/FileDescriptor.java
+++ b/src/java.base/share/classes/java/io/FileDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.Blocker;
 import jdk.internal.ref.PhantomCleanable;
 
 /**
@@ -205,7 +206,17 @@ public final class FileDescriptor {
      *        buffers have been synchronized with physical media.
      * @since     1.1
      */
-    public native void sync() throws SyncFailedException;
+    public void sync() throws SyncFailedException {
+        long comp = Blocker.begin();
+        try {
+            sync0();
+        } finally {
+            Blocker.end(comp);
+        }
+    }
+
+    /* fsync/equivalent this file descriptor */
+    private native void sync0() throws SyncFailedException;
 
     /* This routine initializes JNI field offsets for the class */
     private static native void initIDs();

--- a/src/java.base/unix/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/unix/native/libjava/FileDescriptor_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ Java_java_io_FileDescriptor_initIDs(JNIEnv *env, jclass fdClass) {
  */
 
 JNIEXPORT void JNICALL
-Java_java_io_FileDescriptor_sync(JNIEnv *env, jobject this) {
+Java_java_io_FileDescriptor_sync0(JNIEnv *env, jobject this) {
     FD fd = THIS_FD(this);
     if (IO_Sync(fd) == -1) {
         JNU_ThrowByName(env, "java/io/SyncFailedException", "sync failed");

--- a/src/java.base/windows/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/windows/native/libjava/FileDescriptor_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ Java_java_io_FileDescriptor_initIDs(JNIEnv *env, jclass fdClass) {
  */
 
 JNIEXPORT void JNICALL
-Java_java_io_FileDescriptor_sync(JNIEnv *env, jobject this) {
+Java_java_io_FileDescriptor_sync0(JNIEnv *env, jobject this) {
     FD fd = THIS_FD(this);
     if (IO_Sync(fd) == -1) {
         JNU_ThrowByName(env, "java/io/SyncFailedException", "sync failed");


### PR DESCRIPTION
Clean backport to avoid the temporary loss of platform thread when virtual thread does `fsync`. In https://github.com/openjdk/jdk/pull/15231, I tested that the overhead of doing this for platform threads is very small compared to the cost of the `fsync` itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312127](https://bugs.openjdk.org/browse/JDK-8312127): FileDescriptor.sync should temporarily increase parallelism (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/52.diff">https://git.openjdk.org/jdk21u/pull/52.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/52#issuecomment-1673537679)