### PR TITLE
8309591: Socket.setOption(TCP_QUICKACK) uses wrong level

### DIFF
--- a/src/jdk.net/aix/native/libextnet/AIXSocketOptions.c
+++ b/src/jdk.net/aix/native/libextnet/AIXSocketOptions.c
@@ -86,7 +86,7 @@ JNIEXPORT void JNICALL Java_jdk_net_AIXSocketOptions_setQuickAck0
     int optval;
     int rv;
     optval = (on ? 1 : 0);
-    rv = setsockopt(fd, SOL_SOCKET, TCP_NODELAYACK, &optval, sizeof (optval));
+    rv = setsockopt(fd, IPPROTO_TCP, TCP_NODELAYACK, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_NODELAYACK failed");
 }
 
@@ -99,7 +99,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_AIXSocketOptions_getQuickAck0
 (JNIEnv *env, jobject unused, jint fd) {
     int on;
     socklen_t sz = sizeof (on);
-    int rv = getsockopt(fd, SOL_SOCKET, TCP_NODELAYACK, &on, &sz);
+    int rv = getsockopt(fd, IPPROTO_TCP, TCP_NODELAYACK, &on, &sz);
     handleError(env, rv, "get option TCP_NODELAYACK failed");
     return on != 0;
 }
@@ -111,7 +111,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_AIXSocketOptions_getQuickAck0
  */
 JNIEXPORT jboolean JNICALL Java_jdk_net_AIXSocketOptions_quickAckSupported0
 (JNIEnv *env, jobject unused) {
-    return socketOptionSupported(SOL_SOCKET, TCP_NODELAYACK);
+    return socketOptionSupported(IPPROTO_TCP, TCP_NODELAYACK);
 }
 
 /*

--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setQuickAck0
     int optval;
     int rv;
     optval = (on ? 1 : 0);
-    rv = setsockopt(fd, SOL_SOCKET, TCP_QUICKACK, &optval, sizeof (optval));
+    rv = setsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_QUICKACK failed");
 }
 
@@ -102,7 +102,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_getQuickAck0
 (JNIEnv *env, jobject unused, jint fd) {
     int on;
     socklen_t sz = sizeof (on);
-    int rv = getsockopt(fd, SOL_SOCKET, TCP_QUICKACK, &on, &sz);
+    int rv = getsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, &on, &sz);
     handleError(env, rv, "get option TCP_QUICKACK failed");
     return on != 0;
 }
@@ -114,7 +114,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_getQuickAck0
  */
 JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_quickAckSupported0
 (JNIEnv *env, jobject unused) {
-    return socketOptionSupported(SOL_SOCKET, TCP_QUICKACK);
+    return socketOptionSupported(IPPROTO_TCP, TCP_QUICKACK);
 }
 
 /*


### PR DESCRIPTION
Clean backport to fix TCP_QUICKACK bug.

Additional testing:
 - [x] Linux AArch64 fastdebug, `jdk_net`
 - [x] Linux AArch64 fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309591](https://bugs.openjdk.org/browse/JDK-8309591): Socket.setOption(TCP_QUICKACK) uses wrong level (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/57.diff">https://git.openjdk.org/jdk21u/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/57#issuecomment-1677070535)