### PR TITLE
8314144: gc/g1/ihop/TestIHOPStatic.java fails due to extra concurrent mark with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
@@ -30,6 +30,7 @@
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -28,7 +28,8 @@
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
- * @requires !(vm.graal.enabled & vm.compMode == "Xcomp")
+ * @requires !vm.graal.enabled
+ * @requires vm.compMode != "Xcomp"
  * @requires os.maxMemory > 1G
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi all,

  This pull request contains a backport of commit [19255084](https://github.com/openjdk/jdk/commit/1925508425cf1b2d46173754077a588290253430) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

  The commit being backported was authored by Thomas Schatzl on 16 Aug 2023 and was reviewed by Albert Mingkun Yang and Ivan Walulya.

  Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314144](https://bugs.openjdk.org/browse/JDK-8314144): gc/g1/ihop/TestIHOPStatic.java fails due to extra concurrent mark with -Xcomp (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/68.diff">https://git.openjdk.org/jdk21u/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/68#issuecomment-1681788677)