### PR TITLE
8314423: Multiple patterns without unnamed variables

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4609,6 +4609,19 @@ public class Check {
                 if (!allUnderscore) {
                     log.error(c.labels.tail.head.pos(), Errors.FlowsThroughFromPattern);
                 }
+
+                boolean allPatternCaseLabels = c.labels.stream().allMatch(p -> p instanceof JCPatternCaseLabel);
+
+                if (allPatternCaseLabels) {
+                    preview.checkSourceLevel(c.labels.tail.head.pos(), Feature.UNNAMED_VARIABLES);
+                }
+
+                for (JCCaseLabel label : c.labels.tail) {
+                    if (label instanceof JCConstantCaseLabel) {
+                        log.error(label.pos(), Errors.InvalidCaseLabelCombination);
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3310,6 +3310,8 @@ public class JavacParser implements Parser {
                         } else {
                             pendingResult = PatternResult.PATTERN;
                         }
+                    } else if (typeDepth == 0 && parenDepth == 0 && (peekToken(lookahead, tk -> tk == ARROW || tk == COMMA))) {
+                        return PatternResult.EXPRESSION;
                     }
                     break;
                 case UNDERSCORE:

--- a/test/langtools/tools/javac/T8314216.java
+++ b/test/langtools/tools/javac/T8314216.java
@@ -1,0 +1,18 @@
+/*
+ * @test  /nodynamiccopyright/
+ * @bug 8314216
+ * @summary Multiple patterns without unnamed variables
+ * @compile/fail/ref=T8314216.out -XDrawDiagnostics --enable-preview --source ${jdk.version} T8314216.java
+ */
+
+public class T8314216 {
+    enum X {A, B}
+
+    void test(Object obj) {
+        switch (obj) {
+            case X.A, Integer _ -> System.out.println("A or Integer");
+            case String _, X.B -> System.out.println("B or String");
+            default -> System.out.println("other");
+        }
+    }
+}

--- a/test/langtools/tools/javac/T8314216.out
+++ b/test/langtools/tools/javac/T8314216.out
@@ -1,0 +1,5 @@
+T8314216.java:13:23: compiler.err.invalid.case.label.combination
+T8314216.java:14:28: compiler.err.invalid.case.label.combination
+- compiler.note.preview.filename: T8314216.java, DEFAULT
+- compiler.note.preview.recompile
+2 errors

--- a/test/langtools/tools/javac/T8314423.java
+++ b/test/langtools/tools/javac/T8314423.java
@@ -1,0 +1,23 @@
+/*
+ * @test  /nodynamiccopyright/
+ * @bug 8314423
+ * @summary Multiple patterns without unnamed variables
+ * @compile/fail/ref=T8314423.out -XDrawDiagnostics T8314423.java
+ * @compile --enable-preview --source ${jdk.version} T8314423.java
+ */
+
+public class T8314423 {
+    record R1() {}
+    record R2() {}
+
+    static void test(Object obj) {
+        switch (obj) {
+            case R1(), R2() -> System.out.println("R1 or R2");
+            default -> System.out.println("other");
+        }
+    }
+
+    public static void main(String[] args) {
+        test(new R1());
+    }
+}

--- a/test/langtools/tools/javac/T8314423.out
+++ b/test/langtools/tools/javac/T8314423.out
@@ -1,0 +1,2 @@
+T8314423.java:15:24: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.unnamed.variables)
+1 error


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8314423](https://bugs.openjdk.org/browse/JDK-8314423): Multiple patterns without unnamed variables (**Bug** - P3)
 * [JDK-8314216](https://bugs.openjdk.org/browse/JDK-8314216): Case enumConstant, pattern compilation fails (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/69.diff">https://git.openjdk.org/jdk21u/pull/69.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/69#issuecomment-1681820891)