### PR TITLE
8312976: MatchResult produces StringIndexOutOfBoundsException for groups outside match

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -274,13 +274,40 @@ public final class Matcher implements MatchResult {
      * @since 1.5
      */
     public MatchResult toMatchResult() {
-        String capturedText = hasMatch()
-                ? text.subSequence(first, last).toString()
-                : null;
+        int minStart;
+        String capturedText;
+        if (hasMatch()) {
+            minStart = minStart();
+            capturedText = text.subSequence(minStart, maxEnd()).toString();
+        } else {
+            minStart = -1;
+            capturedText = null;
+        }
         return new ImmutableMatchResult(first, last, groupCount(),
                 groups.clone(), capturedText,
-                namedGroups()
-        );
+                namedGroups(), minStart);
+    }
+
+    private int minStart() {
+        int r = text.length();
+        for (int group = 0; group <= groupCount(); ++group) {
+            int start = groups[group * 2];
+            if (start >= 0) {
+                r = Math.min(r, start);
+            }
+        }
+        return r;
+    }
+
+    private int maxEnd() {
+        int r = 0;
+        for (int group = 0; group <= groupCount(); ++group) {
+            int end = groups[group * 2 + 1];
+            if (end >= 0) {
+                r = Math.max(r, end);
+            }
+        }
+        return r;
     }
 
     private static class ImmutableMatchResult implements MatchResult {
@@ -290,16 +317,18 @@ public final class Matcher implements MatchResult {
         private final int[] groups;
         private final String text;
         private final Map<String, Integer> namedGroups;
+        private final int minStart;
 
         ImmutableMatchResult(int first, int last, int groupCount,
                              int[] groups, String text,
-                             Map<String, Integer> namedGroups) {
+                             Map<String, Integer> namedGroups, int minStart) {
             this.first = first;
             this.last = last;
             this.groupCount = groupCount;
             this.groups = groups;
             this.text = text;
             this.namedGroups = namedGroups;
+            this.minStart = minStart;
         }
 
         @Override
@@ -345,7 +374,7 @@ public final class Matcher implements MatchResult {
             checkGroup(group);
             if ((groups[group * 2] == -1) || (groups[group * 2 + 1] == -1))
                 return null;
-            return text.substring(groups[group * 2] - first, groups[group * 2 + 1] - first);
+            return text.substring(groups[group * 2] - minStart, groups[group * 2 + 1] - minStart);
         }
 
         @Override


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 61c58fdd from the openjdk/jdk repository.

The commit being backported was authored by Raffaello Giulietti on 4 Aug 2023 and was reviewed by Alan Bateman and Stuart Marks.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312976](https://bugs.openjdk.org/browse/JDK-8312976): MatchResult produces StringIndexOutOfBoundsException for groups outside match (**Bug** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/70.diff">https://git.openjdk.org/jdk21u/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/70#issuecomment-1682270514)