### PR TITLE
8302017: Allocate BadPaddingException only if it will be thrown

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -30,7 +30,6 @@ import java.util.*;
 import java.security.*;
 import java.security.spec.*;
 
-import javax.crypto.BadPaddingException;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.OAEPParameterSpec;
 
@@ -236,24 +235,22 @@ public final class RSAPadding {
     }
 
     /**
-     * Pad the data and return the padded block.
+     * Pad the data and return the result or null if error occurred.
      */
-    public byte[] pad(byte[] data) throws BadPaddingException {
+    public byte[] pad(byte[] data) {
         return pad(data, 0, data.length);
     }
 
     /**
-     * Pad the data and return the padded block.
+     * Pad the data and return the result or null if error occurred.
      */
-    public byte[] pad(byte[] data, int ofs, int len)
-            throws BadPaddingException {
+    public byte[] pad(byte[] data, int ofs, int len) {
         if (len > maxDataSize) {
-            throw new BadPaddingException("Data must be shorter than "
-                + (maxDataSize + 1) + " bytes but received "
-                + len + " bytes.");
+            return null;
         }
         switch (type) {
         case PAD_NONE:
+            // assert len == paddedSize and data.length - ofs > len?
             return RSACore.convert(data, ofs, len);
         case PAD_BLOCKTYPE_1:
         case PAD_BLOCKTYPE_2:
@@ -266,24 +263,18 @@ public final class RSAPadding {
     }
 
     /**
-     * Unpad the padded block and return the data.
+     * Unpad the padded block and return the result or null if error occurred.
      */
-    public byte[] unpad(byte[] padded) throws BadPaddingException {
-        if (padded.length != paddedSize) {
-            throw new BadPaddingException("Decryption error. " +
-                "The padded array length (" + padded.length +
-                ") is not the specified padded size (" + paddedSize + ")");
-        }
-        switch (type) {
-        case PAD_NONE:
-            return padded;
-        case PAD_BLOCKTYPE_1:
-        case PAD_BLOCKTYPE_2:
-            return unpadV15(padded);
-        case PAD_OAEP_MGF1:
-            return unpadOAEP(padded);
-        default:
-            throw new AssertionError();
+    public byte[] unpad(byte[] padded) {
+        if (padded.length == paddedSize) {
+            return switch(type) {
+                case PAD_NONE -> padded;
+                case PAD_BLOCKTYPE_1, PAD_BLOCKTYPE_2 -> unpadV15(padded);
+                case PAD_OAEP_MGF1 -> unpadOAEP(padded);
+                default -> throw new AssertionError();
+            };
+        } else {
+            return null;
         }
     }
 
@@ -327,10 +318,10 @@ public final class RSAPadding {
 
     /**
      * PKCS#1 v1.5 unpadding (blocktype 1 (signature) and 2 (encryption)).
-     *
+     * Return the result or null if error occurred.
      * Note that we want to make it a constant-time operation
      */
-    private byte[] unpadV15(byte[] padded) throws BadPaddingException {
+    private byte[] unpadV15(byte[] padded) {
         int k = 0;
         boolean bp = false;
 
@@ -366,10 +357,8 @@ public final class RSAPadding {
         byte[] data = new byte[n];
         System.arraycopy(padded, p, data, 0, n);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
         if (bp) {
-            throw bpe;
+            return null;
         } else {
             return data;
         }
@@ -378,6 +367,7 @@ public final class RSAPadding {
     /**
      * PKCS#1 v2.0 OAEP padding (MGF1).
      * Paragraph references refer to PKCS#1 v2.1 (June 14, 2002)
+     * Return the result or null if error occurred.
      */
     private byte[] padOAEP(byte[] M, int ofs, int len) {
         if (random == null) {
@@ -428,8 +418,9 @@ public final class RSAPadding {
 
     /**
      * PKCS#1 v2.1 OAEP unpadding (MGF1).
+     * Return the result or null if error occurred.
      */
-    private byte[] unpadOAEP(byte[] padded) throws BadPaddingException {
+    private byte[] unpadOAEP(byte[] padded) {
         byte[] EM = padded;
         boolean bp = false;
         int hLen = lHash.length;
@@ -485,12 +476,6 @@ public final class RSAPadding {
         byte [] m = new byte[EM.length - mStart];
         System.arraycopy(EM, mStart, m, 0, m.length);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
-        if (bp) {
-            throw bpe;
-        } else {
-            return m;
-        }
+        return (bp? null : m);
     }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -759,9 +759,12 @@ final class P11Signature extends SignatureSpi {
             int len = (p11Key.length() + 7) >> 3;
             RSAPadding padding = RSAPadding.getInstance
                                         (RSAPadding.PAD_BLOCKTYPE_1, len);
-            byte[] padded = padding.pad(data);
-            return padded;
-        } catch (GeneralSecurityException e) {
+            byte[] result = padding.pad(data);
+            if (result == null) {
+                throw new ProviderException("Error padding data");
+            }
+            return result;
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
             throw new ProviderException(e);
         }
     }

--- a/test/jdk/sun/security/rsa/RSAPaddingCheck.java
+++ b/test/jdk/sun/security/rsa/RSAPaddingCheck.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8302017
+ * @summary Ensure that RSAPadding class works as expected after refactoring
+ * @modules java.base/sun.security.rsa
+ */
+import java.util.Arrays;
+import sun.security.rsa.RSAPadding;
+
+public class RSAPaddingCheck {
+
+    private static int[] PADDING_TYPES =  {
+        RSAPadding.PAD_BLOCKTYPE_1,
+        RSAPadding.PAD_BLOCKTYPE_2,
+        RSAPadding.PAD_NONE,
+        RSAPadding.PAD_OAEP_MGF1,
+    };
+
+    public static void main(String[] args) throws Exception {
+        int size = 2048 >> 3;
+        byte[] testData = "This is some random to-be-padded Data".getBytes();
+        for (int type : PADDING_TYPES) {
+            byte[] data = (type == RSAPadding.PAD_NONE?
+                    Arrays.copyOf(testData, size) : testData);
+            System.out.println("Testing PaddingType: " + type);
+            RSAPadding padding = RSAPadding.getInstance(type, size);
+            byte[] paddedData = padding.pad(data);
+            if (paddedData == null) {
+                throw new RuntimeException("Unexpected padding op failure!");
+            }
+
+            byte[] data2 = padding.unpad(paddedData);
+            if (data2 == null) {
+                throw new RuntimeException("Unexpected unpadding op failure!");
+            }
+            if (!Arrays.equals(data, data2)) {
+                throw new RuntimeException("diff check failure!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a backport of commit c27c8778 from the openjdk/jdk repository.
The commit being backported was authored by Valerie Peng on 27 Jul 2023 and was reviewed by Xue-Lei Andrew Fan.

Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302017](https://bugs.openjdk.org/browse/JDK-8302017): Allocate BadPaddingException only if it will be thrown (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/79.diff">https://git.openjdk.org/jdk21u/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/79#issuecomment-1686932079)