### PR TITLE
8314426: runtime/os/TestTrimNative.java is failing on slow machines

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -170,7 +170,6 @@ public class TestTrimNative {
         if (expectEnabled) {
             output.shouldContain("Periodic native trim enabled (interval: " + expectedInterval + " ms");
             output.shouldContain("Native heap trimmer start");
-            output.shouldContain("Native heap trimmer stop");
         } else {
             output.shouldNotContain("Periodic native trim enabled");
         }
@@ -251,7 +250,7 @@ public class TestTrimNative {
             System.gc();
 
             // give GC time to react
-            System.out.println("Sleeping...");
+            System.out.println("Sleeping for " + sleeptime + " ms...");
             Thread.sleep(sleeptime);
             System.out.println("Done.");
         }
@@ -296,12 +295,15 @@ public class TestTrimNative {
 
             case "trimNativeLowInterval":
             case "trimNativeLowIntervalStrict": {
+                long ms1 = System.currentTimeMillis();
                 OutputAnalyzer output = runTestWithOptions(
                         new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=1" },
                         new String[] { TestTrimNative.Tester.class.getName(), "0" }
                 );
+                long ms2 = System.currentTimeMillis();
+                int maxTrimsExpected = (int)(ms2 - ms1); // 1ms trim interval
                 checkExpectedLogMessages(output, true, 1);
-                parseOutputAndLookForNegativeTrim(output, 1, 3000, strictTesting);
+                parseOutputAndLookForNegativeTrim(output, 1, (int)maxTrimsExpected, strictTesting);
             } break;
 
             case "testOffOnNonCompliantPlatforms": {


### PR DESCRIPTION
Clean backport to stabilize the test.

Additional testing:
 - [x] 100+ repetitions of affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314426](https://bugs.openjdk.org/browse/JDK-8314426): runtime/os/TestTrimNative.java is failing on slow machines (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/86.diff">https://git.openjdk.org/jdk21u/pull/86.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/86#issuecomment-1689594385)