### PR TITLE
8313752: InstanceKlassFlags::print_on doesn't print the flag names

### DIFF
--- a/src/hotspot/share/oops/constMethodFlags.cpp
+++ b/src/hotspot/share/oops/constMethodFlags.cpp
@@ -29,7 +29,7 @@
 
 void ConstMethodFlags::print_on(outputStream* st) const {
 #define CM_PRINT(name, ignore)          \
-  if (name()) st->print(" " #name " ");
+  if (name()) st->print(#name " ");
   CM_FLAGS_DO(CM_PRINT)
 #undef CM_PRINT
 }

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -32,11 +32,10 @@
 
 void InstanceKlassFlags::print_on(outputStream* st) const {
 #define IK_FLAGS_PRINT(name, ignore)          \
-  if (name()) st->print(" ##name ");
+  if (name()) st->print(#name " ");
   IK_FLAGS_DO(IK_FLAGS_PRINT)
   IK_STATUS_DO(IK_FLAGS_PRINT)
 #undef IK_FLAGS_PRINT
-  st->cr();
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/methodFlags.cpp
+++ b/src/hotspot/share/oops/methodFlags.cpp
@@ -28,7 +28,7 @@
 
 void MethodFlags::print_on(outputStream* st) const {
 #define M_PRINT(name, ignore)          \
-  if (name()) st->print(" " #name " ");
+  if (name()) st->print(#name " ");
   M_STATUS_DO(M_PRINT)
 #undef M_PRINT
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -56,5 +56,8 @@ public class PrintClasses {
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("instance size");
     output.shouldContain(PrintClasses.class.getSimpleName());
+
+    // Test for previous bug in misc flags printing
+    output.shouldNotContain("##name");
   }
 }


### PR DESCRIPTION
Clean backport to fix JDK 21 regression in diagnostic printing.

Additional testing:
 - [x] New test passes with the fix, fails without it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313752](https://bugs.openjdk.org/browse/JDK-8313752): InstanceKlassFlags::print_on doesn't print the flag names (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/87.diff">https://git.openjdk.org/jdk21u/pull/87.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/87#issuecomment-1689593478)