### PR TITLE
Backport 028b3ae1b162bd8f7c340bfa6e9487ca83697955

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2876,7 +2876,7 @@ JNI_ENTRY(jweak, jni_NewWeakGlobalRef(JNIEnv *env, jobject ref))
   HOTSPOT_JNI_NEWWEAKGLOBALREF_ENTRY(env, ref);
   Handle ref_handle(thread, JNIHandles::resolve(ref));
   jweak ret = JNIHandles::make_weak_global(ref_handle, AllocFailStrategy::RETURN_NULL);
-  if (ret == nullptr) {
+  if (ret == nullptr && ref_handle.not_null()) {
     THROW_OOP_(Universe::out_of_memory_error_c_heap(), nullptr);
   }
   HOTSPOT_JNI_NEWWEAKGLOBALREF_RETURN(ret);

--- a/test/hotspot/jtreg/runtime/jni/ReturnJNIWeak/ReturnJNIWeak.java
+++ b/test/hotspot/jtreg/runtime/jni/ReturnJNIWeak/ReturnJNIWeak.java
@@ -123,9 +123,19 @@ public final class ReturnJNIWeak {
         }
     }
 
+    // Verify passing a null value returns null and doesn't throw.
+    private static void testNullValue() {
+        System.out.println("running testNullValue");
+        registerObject(null);
+        if (getObject() != null) {
+            throw new RuntimeException("expected null");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         testSanity();
         testSurvival();
         testClear();
+        testNullValue();
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [028b3ae1](https://github.com/openjdk/jdk/commit/028b3ae1b162bd8f7c340bfa6e9487ca83697955) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Oli Gillespie on 10 Aug 2023 and was reviewed by David Holmes, Kim Barrett and Aleksey Shipilev.

Thanks!