### PR TITLE
8309214: sun/security/pkcs11/KeyStore/CertChainRemoval.java fails after 8301154

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -1559,22 +1559,50 @@ final class P11KeyStore extends KeyStoreSpi {
                                 cert.getSerialNumber().toByteArray()));
         attrList.add(new CK_ATTRIBUTE(CKA_VALUE, cert.getEncoded()));
 
-        if (alias != null) {
-            attrList.add(new CK_ATTRIBUTE(CKA_LABEL, alias));
-            attrList.add(new CK_ATTRIBUTE(CKA_ID, alias));
-        } else {
-            // ibutton requires something to be set
-            // - alias must be unique
-            attrList.add(new CK_ATTRIBUTE(CKA_ID,
-                        getID(cert.getSubjectX500Principal().getName
-                                        (X500Principal.CANONICAL), cert)));
-        }
-
         Session session = null;
         try {
             session = token.getOpSession();
+            long[] ch = findObjects(session,
+                    attrList.toArray(new CK_ATTRIBUTE[attrList.size()]));
+            if (ch.length != 0) { // found a match
+                if (debug != null) {
+                    String certInfo = (alias == null?
+                            "CA cert " + cert.getSubjectX500Principal() :
+                            "EE cert for alias " + alias);
+                    debug.println("storeCert: found a match for " + certInfo);
+                }
+                if (alias != null) {
+                    // Add the alias to the existing cert
+                    CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_LABEL, alias),
+                        new CK_ATTRIBUTE(CKA_ID, alias) };
+                    token.p11.C_SetAttributeValue
+                        (session.id(), ch[0], attrs);
+                    if (debug != null) {
+                        debug.println("storeCert: added alias: " + alias);
+                    }
+                }
+                // done; no need to create the cert
+                return;
+            }
+            if (alias != null) {
+                attrList.add(new CK_ATTRIBUTE(CKA_LABEL, alias));
+                attrList.add(new CK_ATTRIBUTE(CKA_ID, alias));
+            } else {
+                // ibutton requires something to be set
+                // - alias must be unique
+                attrList.add(new CK_ATTRIBUTE(CKA_ID,
+                        getID(cert.getSubjectX500Principal().getName
+                                        (X500Principal.CANONICAL), cert)));
+            }
             token.p11.C_CreateObject(session.id(),
-                        attrList.toArray(new CK_ATTRIBUTE[attrList.size()]));
+                    attrList.toArray(new CK_ATTRIBUTE[attrList.size()]));
+            if (debug != null) {
+                String certInfo = (alias == null?
+                        "CA cert " + cert.getSubjectX500Principal() :
+                        "EE cert for alias " + alias);
+                debug.println("storeCert: created " + certInfo);
+            }
         } finally {
             token.releaseSession(session);
         }
@@ -1587,7 +1615,6 @@ final class P11KeyStore extends KeyStoreSpi {
         //
         // end cert has CKA_LABEL and CKA_ID set to alias.
         // other certs in chain have neither set.
-
         storeCert(alias, chain[0]);
         storeCaCerts(chain, 1);
     }

--- a/test/jdk/sun/security/pkcs11/KeyStore/CertChainRemoval.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/CertChainRemoval.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8301154
+ * @bug 8301154 8309214
  * @summary test cert chain deletion logic w/ NSS PKCS11 KeyStore
  * @library /test/lib ..
  * @run testng/othervm CertChainRemoval


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [ba6cdbe2](https://github.com/openjdk/jdk/commit/ba6cdbe2c2897a0fdc266119f0fe4545c3352b8e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Valerie Peng on 22 Aug 2023 and was reviewed by Matthias Baesken and Jamil Nimeh.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309214](https://bugs.openjdk.org/browse/JDK-8309214): sun/security/pkcs11/KeyStore/CertChainRemoval.java fails after 8301154 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/93.diff">https://git.openjdk.org/jdk21u/pull/93.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/93#issuecomment-1690497429)