### PR TITLE
8308042: [macos] Developer ID Application Certificate not picked up by jpackage if it contains UNICODE characters

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,13 +62,13 @@ public class MacAppBundler extends AppImageBundler {
                     String keychain = SIGNING_KEYCHAIN.fetchFrom(params);
                     String result = null;
                     if (APP_STORE.fetchFrom(params)) {
-                        result = MacBaseInstallerBundler.findKey(
+                        result = MacCertificate.findCertificateKey(
                             "3rd Party Mac Developer Application: ",
                             user, keychain);
                     }
                     // if either not signing for app store or couldn't find
                     if (result == null) {
-                        result = MacBaseInstallerBundler.findKey(
+                        result = MacCertificate.findCertificateKey(
                             "Developer ID Application: ", user, keychain);
                     }
 

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
@@ -207,47 +207,5 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
         return "INSTALLER";
     }
 
-    public static String findKey(String keyPrefix, String teamName, String keychainName) {
-
-        boolean useAsIs = teamName.startsWith(keyPrefix)
-                || teamName.startsWith("Developer ID")
-                || teamName.startsWith("3rd Party Mac");
-
-        String key = (useAsIs) ? teamName : (keyPrefix + teamName);
-
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                PrintStream ps = new PrintStream(baos)) {
-            List<String> searchOptions = new ArrayList<>();
-            searchOptions.add("/usr/bin/security");
-            searchOptions.add("find-certificate");
-            searchOptions.add("-c");
-            searchOptions.add(key);
-            searchOptions.add("-a");
-            if (keychainName != null && !keychainName.isEmpty()) {
-                searchOptions.add(keychainName);
-            }
-
-            ProcessBuilder pb = new ProcessBuilder(searchOptions);
-
-            IOUtils.exec(pb, false, ps);
-            Pattern p = Pattern.compile("\"alis\"<blob>=\"([^\"]+)\"");
-            Matcher m = p.matcher(baos.toString());
-            if (!m.find()) {
-                Log.error(MessageFormat.format(I18N.getString(
-                        "error.cert.not.found"), key, keychainName));
-                return null;
-            }
-            String matchedKey = m.group(1);
-            if (m.find()) {
-                Log.error(MessageFormat.format(I18N.getString(
-                        "error.multiple.certs.found"), key, keychainName));
-            }
-            return matchedKey;
-        } catch (IOException ioe) {
-            Log.verbose(ioe);
-            return null;
-        }
-    }
-
     private final Bundler appImageBundler;
 }

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DateFormat;
+import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -40,6 +41,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.HexFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class MacCertificate {
     private final String certificate;
@@ -52,35 +56,219 @@ public final class MacCertificate {
         return verifyCertificate(this.certificate);
     }
 
-    private static Path findCertificate(String certificate) {
-        Path result = null;
+    public static String findCertificateKey(String keyPrefix, String teamName,
+                                            String keychainName) {
 
+        String matchedKey = null;
+        boolean useAsIs = (keyPrefix == null)
+                || teamName.startsWith(keyPrefix)
+                || teamName.startsWith("Developer ID")
+                || teamName.startsWith("3rd Party Mac");
+
+        String name = (useAsIs) ? teamName : (keyPrefix + teamName);
+
+        String output = getFindCertificateOutput(name, keychainName);
+        if (output == null) {
+            Log.error(MessageFormat.format(I18N.getString(
+                        "error.cert.not.found"), name, keychainName));
+            return null;
+        }
+
+        // Check and warn user if multiple certificates found
+        // We will use different regex to count certificates.
+        // ASCII case: "alis"<blob>="NAME"
+        // UNICODE case: "alis"<blob>=0xSOMEHEXDIGITS  "NAME (\SOMEDIGITS)"
+        // In UNICODE case name will contain octal sequence representing UTF-8
+        // characters.
+        // Just look for at least two '"alis"<blob>'.
+        Pattern p = Pattern.compile("\"alis\"<blob>");
+        Matcher m = p.matcher(output);
+        if (m.find() && m.find()) {
+            Log.error(MessageFormat.format(I18N.getString(
+                        "error.multiple.certs.found"), name, keychainName));
+        }
+
+        // Try to get ASCII only certificate first. This aproach only works
+        // if certificate name has ASCII only characters in name. For certificates
+        // with UNICODE characters in name we will use combination of "security"
+        // and "openssl". We keeping ASCII only aproach to avoid regressions and
+        // it works for many use cases.
+        p = Pattern.compile("\"alis\"<blob>=\"([^\"]+)\"");
+        m = p.matcher(output);
+        if (m.find()) {
+            matchedKey = m.group(1);;
+        }
+
+        // Maybe it has UNICODE characters in name. In this case use "security"
+        // and "openssl" to exctract name. We cannot use just "security", since
+        // name can be truncated.
+        if (matchedKey == null) {
+            Path  file = null;
+            try {
+                file = getFindCertificateOutputPEM(name, keychainName);
+                if (file != null) {
+                    matchedKey = findCertificateSubject(
+                                    file.toFile().getCanonicalPath());
+                }
+            } catch (IOException ioe) {
+                Log.verbose(ioe);
+            } finally {
+                try {
+                    Files.deleteIfExists(file);
+                } catch (IOException ignored) {}
+            }
+        }
+
+        if (matchedKey == null) {
+            Log.error(MessageFormat.format(I18N.getString(
+                "error.cert.not.found"), name, keychainName));
+        }
+
+        return matchedKey;
+    }
+
+    private static String getFindCertificateOutput(String name,
+                                                   String keychainName) {
+        try (ByteArrayOutputStream baos = getFindCertificateOutput(name,
+                                                                   keychainName,
+                                                                   false)) {
+            if (baos != null) {
+                return baos.toString();
+            }
+        } catch (IOException ioe) {
+            Log.verbose(ioe);
+        }
+
+        return null;
+    }
+
+    private static Path getFindCertificateOutputPEM(String name,
+                                                    String keychainName) {
+        Path output = null;
+        try (ByteArrayOutputStream baos = getFindCertificateOutput(name,
+                                                                   keychainName,
+                                                                   true)) {
+            if (baos != null) {
+                output = Files.createTempFile("tempfile", ".tmp");
+                Files.copy(new ByteArrayInputStream(baos.toByteArray()),
+                        output, StandardCopyOption.REPLACE_EXISTING);
+                return output;
+            }
+        } catch (IOException ioe) {
+            Log.verbose(ioe);
+            try {
+                Files.deleteIfExists(output);
+            } catch (IOException ignored) {}
+        }
+
+        return null;
+    }
+
+    private static ByteArrayOutputStream getFindCertificateOutput(String name,
+                                                                  String keychainName,
+                                                                  boolean isPEMFormat) {
         List<String> args = new ArrayList<>();
         args.add("/usr/bin/security");
         args.add("find-certificate");
         args.add("-c");
-        args.add(certificate);
+        args.add(name);
         args.add("-a");
-        args.add("-p");
+        if (isPEMFormat) {
+            args.add("-p");
+        }
+        if (keychainName != null && !keychainName.isEmpty()) {
+            args.add(keychainName);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(baos)) {
+            ProcessBuilder pb = new ProcessBuilder(args);
+            IOUtils.exec(pb, false, ps);
+            return baos;
+        } catch (IOException ioe) {
+            Log.verbose(ioe);
+            return null;
+        }
+    }
+
+    private static String findCertificateSubject(String filename) {
+        String result = null;
+
+        List<String> args = new ArrayList<>();
+        args.add("/usr/bin/openssl");
+        args.add("x509");
+        args.add("-noout");
+        args.add("-subject");
+        args.add("-in");
+        args.add(filename);
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 PrintStream ps = new PrintStream(baos)) {
             ProcessBuilder security = new ProcessBuilder(args);
             IOUtils.exec(security, false, ps);
-
-            Path output = Files.createTempFile("tempfile", ".tmp");
-
-            Files.copy(new ByteArrayInputStream(baos.toByteArray()),
-                    output, StandardCopyOption.REPLACE_EXISTING);
-
-            result = output;
+            String output = baos.toString().strip();
+            // Example output:
+            // subject= /UID=ABCDABCD/CN=jpackage.openjdk.java.net (\xC3\xB6) (ABCDABCD)/C=US
+            // We need 'CN' value
+            String [] pairs = output.split("/");
+            for (String pair : pairs) {
+                if (pair.startsWith("CN=")) {
+                    result = pair.substring(3);
+                    // Convert escaped UTF-8 code points to characters
+                    result = convertHexToChar(result);
+                    break;
+                }
+            }
+        } catch (IOException ex) {
+            Log.verbose(ex);
         }
-        catch (IOException ignored) {}
 
         return result;
     }
 
-    private static Date findCertificateDate(String filename) {
+    // Certificate name with Unicode will be:
+    // Developer ID Application: jpackage.openjdk.java.net (\xHH\xHH)
+    // Convert UTF-8 code points '\xHH\xHH' to character.
+    private static String convertHexToChar(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        if (!input.contains("\\x")) {
+            return input;
+        }
+
+        StringBuilder output = new StringBuilder();
+        try {
+            int len = input.length();
+            for (int i = 0; i < len; i++) {
+                if (input.codePointAt(i) == '\\' &&
+                    (i + 8) <= len &&
+                    input.codePointAt(i + 1) == 'x' &&
+                    input.codePointAt(i + 4) == '\\' &&
+                    input.codePointAt(i + 5) == 'x') {
+                        // We found '\xHH\xHH'
+                        // HEX code points to byte array
+                        byte [] bytes = HexFormat.of().parseHex(
+                            input.substring(i + 2, i + 4) + input.substring(i + 6, i + 8));
+                        // Byte array with UTF-8 code points to character
+                        output.append(new String(bytes, "UTF-8"));
+                        i += 7; // Skip '\xHH\xHH'
+                } else {
+                    output.appendCodePoint(input.codePointAt(i));
+                }
+            }
+        } catch (Exception ex) {
+            Log.verbose(ex);
+            // We will consider any excpetions during conversion as
+            // certificate not found.
+            return null;
+        }
+
+        return output.toString();
+    }
+
+    private Date findCertificateDate(String filename) {
         Date result = null;
 
         List<String> args = new ArrayList<>();
@@ -107,7 +295,7 @@ public final class MacCertificate {
         return result;
     }
 
-    private static boolean verifyCertificate(String certificate) {
+    private boolean verifyCertificate(String certificate) {
         boolean result = false;
 
         try {
@@ -115,16 +303,15 @@ public final class MacCertificate {
             Date certificateDate = null;
 
             try {
-                file = findCertificate(certificate);
+                file = getFindCertificateOutputPEM(certificate, null);
 
                 if (file != null) {
                     certificateDate = findCertificateDate(
                             file.toFile().getCanonicalPath());
                 }
-            }
-            finally {
+            } finally {
                 if (file != null) {
-                    Files.delete(file);
+                    Files.deleteIfExists(file);
                 }
             }
 

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -110,13 +110,13 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
                     String keychain = SIGNING_KEYCHAIN.fetchFrom(params);
                     String result = null;
                     if (APP_STORE.fetchFrom(params)) {
-                        result = MacBaseInstallerBundler.findKey(
+                        result = MacCertificate.findCertificateKey(
                             "3rd Party Mac Developer Installer: ",
                             user, keychain);
                     }
                     // if either not signing for app store or couldn't find
                     if (result == null) {
-                        result = MacBaseInstallerBundler.findKey(
+                        result = MacCertificate.findCertificateKey(
                             "Developer ID Installer: ", user, keychain);
                     }
 

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,31 +61,37 @@ import jdk.jpackage.test.AdditionalLauncher;
 public class SigningAppImageTest {
 
     @Test
-    @Parameter("true")
-    @Parameter("false")
-    public void test(boolean doSign) throws Exception {
-        SigningCheck.checkCertificates();
+    @Parameter({"true", "0"}) // ({"sign or not", "certificate index"})
+    @Parameter({"true", "1"})
+    @Parameter({"false", "-1"})
+    public void test(String... testArgs) throws Exception {
+        boolean doSign = Boolean.parseBoolean(testArgs[0]);
+        int certIndex = Integer.parseInt(testArgs[1]);
+
+        SigningCheck.checkCertificates(certIndex);
 
         JPackageCommand cmd = JPackageCommand.helloAppImage();
         if (doSign) {
-            cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                    SigningBase.DEV_NAME, "--mac-signing-keychain",
-                    SigningBase.KEYCHAIN);
+            cmd.addArguments("--mac-sign",
+                    "--mac-signing-key-user-name",
+                    SigningBase.getDevName(certIndex),
+                    "--mac-signing-keychain",
+                    SigningBase.getKeyChain());
         }
         AdditionalLauncher testAL = new AdditionalLauncher("testAL");
         testAL.applyTo(cmd);
         cmd.executeAndAssertHelloAppImageCreated();
 
         Path launcherPath = cmd.appLauncherPath();
-        SigningBase.verifyCodesign(launcherPath, doSign);
+        SigningBase.verifyCodesign(launcherPath, doSign, certIndex);
 
         Path testALPath = launcherPath.getParent().resolve("testAL");
-        SigningBase.verifyCodesign(testALPath, doSign);
+        SigningBase.verifyCodesign(testALPath, doSign, certIndex);
 
         Path appImage = cmd.outputBundle();
-        SigningBase.verifyCodesign(appImage, doSign);
+        SigningBase.verifyCodesign(appImage, doSign, certIndex);
         if (doSign) {
-            SigningBase.verifySpctl(appImage, "exec");
+            SigningBase.verifySpctl(appImage, "exec", certIndex);
         }
     }
 }

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTwoStepsTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTwoStepsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class SigningAppImageTwoStepsTest {
     @Parameter("true")
     @Parameter("false")
     public void test(boolean signAppImage) throws Exception {
-        SigningCheck.checkCertificates();
+        SigningCheck.checkCertificates(SigningBase.DEFAULT_INDEX);
 
         Path appimageOutput = TKit.createTempDirectory("appimage");
 
@@ -75,9 +75,11 @@ public class SigningAppImageTwoStepsTest {
         JPackageCommand appImageCmd = JPackageCommand.helloAppImage()
                 .setArgumentValue("--dest", appimageOutput);
         if (signAppImage) {
-            appImageCmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                    SigningBase.DEV_NAME, "--mac-signing-keychain",
-                    SigningBase.KEYCHAIN);
+            appImageCmd.addArguments("--mac-sign",
+                    "--mac-signing-key-user-name",
+                    SigningBase.getDevName(SigningBase.DEFAULT_INDEX),
+                    "--mac-signing-keychain",
+                    SigningBase.getKeyChain());
         }
 
         // Add addtional launcher
@@ -95,8 +97,9 @@ public class SigningAppImageTwoStepsTest {
         cmd.setPackageType(PackageType.IMAGE)
             .addArguments("--app-image", appImageCmd.outputBundle().toAbsolutePath())
             .addArguments("--mac-sign")
-            .addArguments("--mac-signing-key-user-name", SigningBase.DEV_NAME)
-            .addArguments("--mac-signing-keychain", SigningBase.KEYCHAIN);
+            .addArguments("--mac-signing-key-user-name",
+                SigningBase.getDevName(SigningBase.DEFAULT_INDEX))
+            .addArguments("--mac-signing-keychain", SigningBase.getKeyChain());
         cmd.executeAndAssertImageCreated();
 
         // Should be signed app image

--- a/test/jdk/tools/jpackage/macosx/SigningPackageFromTwoStepAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageFromTwoStepAppImageTest.java
@@ -72,8 +72,8 @@ public class SigningPackageFromTwoStepAppImageTest {
         }
 
         Path outputBundle = cmd.outputBundle();
-        SigningBase.verifyPkgutil(outputBundle);
-        SigningBase.verifySpctl(outputBundle, "install");
+        SigningBase.verifyPkgutil(outputBundle, SigningBase.DEFAULT_INDEX);
+        SigningBase.verifySpctl(outputBundle, "install", SigningBase.DEFAULT_INDEX);
     }
 
     private static void verifyDMG(JPackageCommand cmd) {
@@ -89,9 +89,9 @@ public class SigningPackageFromTwoStepAppImageTest {
             if (dmgImage.endsWith(cmd.name() + ".app")) {
                 Path launcherPath = ApplicationLayout.platformAppImage()
                     .resolveAt(dmgImage).launchersDirectory().resolve(cmd.name());
-                SigningBase.verifyCodesign(launcherPath, true);
-                SigningBase.verifyCodesign(dmgImage, true);
-                SigningBase.verifySpctl(dmgImage, "exec");
+                SigningBase.verifyCodesign(launcherPath, true, SigningBase.DEFAULT_INDEX);
+                SigningBase.verifyCodesign(dmgImage, true, SigningBase.DEFAULT_INDEX);
+                SigningBase.verifySpctl(dmgImage, "exec", SigningBase.DEFAULT_INDEX);
             }
         });
     }
@@ -100,7 +100,7 @@ public class SigningPackageFromTwoStepAppImageTest {
     @Parameter("true")
     @Parameter("false")
     public static void test(boolean signAppImage) throws Exception {
-        SigningCheck.checkCertificates();
+        SigningCheck.checkCertificates(SigningBase.DEFAULT_INDEX);
 
         Path appimageOutput = TKit.createTempDirectory("appimage");
 
@@ -111,8 +111,8 @@ public class SigningPackageFromTwoStepAppImageTest {
                 .setArgumentValue("--dest", appimageOutput);
         if (signAppImage) {
             appImageCmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                    SigningBase.DEV_NAME, "--mac-signing-keychain",
-                    SigningBase.KEYCHAIN);
+                    SigningBase.getDevName(SigningBase.DEFAULT_INDEX),
+                    "--mac-signing-keychain", SigningBase.getKeyChain());
         }
 
         // Generate app image
@@ -126,8 +126,9 @@ public class SigningPackageFromTwoStepAppImageTest {
         appImageSignedCmd.setPackageType(PackageType.IMAGE)
             .addArguments("--app-image", appImageCmd.outputBundle().toAbsolutePath())
             .addArguments("--mac-sign")
-            .addArguments("--mac-signing-key-user-name", SigningBase.DEV_NAME)
-            .addArguments("--mac-signing-keychain", SigningBase.KEYCHAIN);
+            .addArguments("--mac-signing-key-user-name",
+                SigningBase.getDevName(SigningBase.DEFAULT_INDEX))
+            .addArguments("--mac-signing-keychain", SigningBase.getKeyChain());
         appImageSignedCmd.executeAndAssertImageCreated();
 
         // Should be signed app image
@@ -141,9 +142,9 @@ public class SigningPackageFromTwoStepAppImageTest {
                     if (signAppImage) {
                         cmd.addArguments("--mac-sign",
                                 "--mac-signing-key-user-name",
-                                SigningBase.DEV_NAME,
+                                SigningBase.getDevName(SigningBase.DEFAULT_INDEX),
                                 "--mac-signing-keychain",
-                                SigningBase.KEYCHAIN);
+                                SigningBase.getKeyChain());
                     }
                 })
                 .forTypes(PackageType.MAC_PKG)

--- a/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
@@ -28,6 +28,7 @@ import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.MacHelper;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Annotations.Parameter;
 
 /**
  * Tests generation of dmg and pkg with --mac-sign and related arguments.
@@ -65,8 +66,8 @@ public class SigningPackageTest {
 
     private static void verifyPKG(JPackageCommand cmd) {
         Path outputBundle = cmd.outputBundle();
-        SigningBase.verifyPkgutil(outputBundle);
-        SigningBase.verifySpctl(outputBundle, "install");
+        SigningBase.verifyPkgutil(outputBundle, getCertIndex(cmd));
+        SigningBase.verifySpctl(outputBundle, "install", getCertIndex(cmd));
     }
 
     private static void verifyDMG(JPackageCommand cmd) {
@@ -81,24 +82,31 @@ public class SigningPackageTest {
             // We will be called with all folders in DMG since JDK-8263155, but
             // we only need to verify app.
             if (dmgImage.endsWith(cmd.name() + ".app")) {
-                SigningBase.verifyCodesign(launcherPath, true);
-                SigningBase.verifyCodesign(dmgImage, true);
-                SigningBase.verifySpctl(dmgImage, "exec");
+                SigningBase.verifyCodesign(launcherPath, true, getCertIndex(cmd));
+                SigningBase.verifyCodesign(dmgImage, true, getCertIndex(cmd));
+                SigningBase.verifySpctl(dmgImage, "exec", getCertIndex(cmd));
             }
         });
     }
 
+    private static int getCertIndex(JPackageCommand cmd) {
+        String devName = cmd.getArgumentValue("--mac-signing-key-user-name");
+        return SigningBase.getDevNameIndex(devName);
+    }
+
     @Test
-    public static void test() throws Exception {
-        SigningCheck.checkCertificates();
+    @Parameter("0")
+    @Parameter("1")
+    public static void test(int certIndex) throws Exception {
+        SigningCheck.checkCertificates(certIndex);
 
         new PackageTest()
                 .configureHelloApp()
                 .forTypes(PackageType.MAC)
                 .addInitializer(cmd -> {
                     cmd.addArguments("--mac-sign",
-                            "--mac-signing-key-user-name", SigningBase.DEV_NAME,
-                            "--mac-signing-keychain", SigningBase.KEYCHAIN);
+                            "--mac-signing-key-user-name", SigningBase.getDevName(certIndex),
+                            "--mac-signing-keychain", SigningBase.getKeyChain());
                 })
                 .forTypes(PackageType.MAC_PKG)
                 .addBundleVerifier(SigningPackageTest::verifyPKG)

--- a/test/jdk/tools/jpackage/macosx/SigningPackageTwoStepTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTwoStepTest.java
@@ -73,8 +73,8 @@ public class SigningPackageTwoStepTest {
         }
 
         Path outputBundle = cmd.outputBundle();
-        SigningBase.verifyPkgutil(outputBundle);
-        SigningBase.verifySpctl(outputBundle, "install");
+        SigningBase.verifyPkgutil(outputBundle, SigningBase.DEFAULT_INDEX);
+        SigningBase.verifySpctl(outputBundle, "install", SigningBase.DEFAULT_INDEX);
     }
 
     private static void verifyDMG(JPackageCommand cmd) {
@@ -91,10 +91,10 @@ public class SigningPackageTwoStepTest {
                 boolean isSigned = cmd.hasArgument("--mac-sign");
                 Path launcherPath = ApplicationLayout.platformAppImage()
                     .resolveAt(dmgImage).launchersDirectory().resolve(cmd.name());
-                SigningBase.verifyCodesign(launcherPath, isSigned);
-                SigningBase.verifyCodesign(dmgImage, isSigned);
+                SigningBase.verifyCodesign(launcherPath, isSigned, SigningBase.DEFAULT_INDEX);
+                SigningBase.verifyCodesign(dmgImage, isSigned, SigningBase.DEFAULT_INDEX);
                 if (isSigned) {
-                    SigningBase.verifySpctl(dmgImage, "exec");
+                    SigningBase.verifySpctl(dmgImage, "exec", SigningBase.DEFAULT_INDEX);
                 }
             }
         });
@@ -104,7 +104,7 @@ public class SigningPackageTwoStepTest {
     @Parameter("true")
     @Parameter("false")
     public static void test(boolean signAppImage) throws Exception {
-        SigningCheck.checkCertificates();
+        SigningCheck.checkCertificates(0);
 
         Path appimageOutput = TKit.createTempDirectory("appimage");
 
@@ -113,9 +113,9 @@ public class SigningPackageTwoStepTest {
         if (signAppImage) {
             appImageCmd.addArguments("--mac-sign")
                     .addArguments("--mac-signing-key-user-name",
-                            SigningBase.DEV_NAME)
+                            SigningBase.getDevName(0))
                     .addArguments("--mac-signing-keychain",
-                            SigningBase.KEYCHAIN);
+                            SigningBase.getKeyChain());
         }
 
         new PackageTest()
@@ -127,9 +127,9 @@ public class SigningPackageTwoStepTest {
                     if (signAppImage) {
                         cmd.addArguments("--mac-sign",
                                 "--mac-signing-key-user-name",
-                                SigningBase.DEV_NAME,
+                                SigningBase.getDevName(0),
                                 "--mac-signing-keychain",
-                                SigningBase.KEYCHAIN);
+                                SigningBase.getKeyChain());
                     }
                 })
                 .forTypes(PackageType.MAC_PKG)


### PR DESCRIPTION
Clean backport of JDK-8308042.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308042](https://bugs.openjdk.org/browse/JDK-8308042): [macos] Developer ID Application Certificate not picked up by jpackage if it contains UNICODE characters (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/95.diff">https://git.openjdk.org/jdk21u/pull/95.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/95#issuecomment-1690778739)