### PR TITLE
8313262: C2:  Sinking node may cause required cast to be dropped

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1642,7 +1642,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
             // Find control for 'x' next to use but not inside inner loops.
             x_ctrl = place_outside_loop(x_ctrl, n_loop);
             // Replace all uses
-            if (u->is_ConstraintCast() && u->bottom_type()->higher_equal(_igvn.type(n)) && u->in(0) == x_ctrl) {
+            if (u->is_ConstraintCast() && _igvn.type(n)->higher_equal(u->bottom_type()) && u->in(0) == x_ctrl) {
               // If we're sinking a chain of data nodes, we might have inserted a cast to pin the use which is not necessary
               // anymore now that we're going to pin n as well
               _igvn.replace_node(u, x);

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestSinkingNodeDropsNotNullCast.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestSinkingNodeDropsNotNullCast.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8313262
+ * @summary Sinking node may cause required cast to be dropped
+ * @requires vm.gc.Shenandoah
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+UseShenandoahGC TestSinkingNodeDropsNotNullCast
+ */
+
+import java.util.Arrays;
+
+public class TestSinkingNodeDropsNotNullCast {
+    public static void main(String[] args) {
+        Object[] array1 = new Object[100];
+        Object[] array2 = new Object[100];
+        Arrays.fill(array2, new Object());
+        for (int i = 0; i < 20_000; i++) {
+            test(array1);
+            test(array1);
+            test(array2);
+        }
+    }
+
+    private static Object test(Object[] array) {
+        Object o;
+        int i = 1;
+        do {
+            synchronized (new Object()) {
+            }
+            o = array[i];
+            if (o != null) {
+                if (o instanceof A) {
+                    return ((A) o).field;
+                } else {
+                    return o;
+                }
+            }
+            i++;
+        } while (i < 100);
+        return o;
+    }
+
+    private static class A {
+        Object field;
+    }
+}


### PR DESCRIPTION
Clean backport to fix recent JDK 21 backport regression.

Additional testing:
 - [x] New test fails without the fix, passes with it
 - [x] Linux x86_64 AArch64 `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313262](https://bugs.openjdk.org/browse/JDK-8313262): C2:  Sinking node may cause required cast to be dropped (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/99.diff">https://git.openjdk.org/jdk21u/pull/99.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/99#issuecomment-1691139420)