### PR TITLE
8314850: SharedRuntime::handle_wrong_method() gets called too often when resolving Continuation.enter

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1872,7 +1872,8 @@ methodHandle SharedRuntime::reresolve_call_site(TRAPS) {
   // nmethod could be deoptimized by the time we get here
   // so no update to the caller is needed.
 
-  if (caller.is_compiled_frame() && !caller.is_deoptimized_frame()) {
+  if ((caller.is_compiled_frame() && !caller.is_deoptimized_frame()) ||
+      (caller.is_native_frame() && ((CompiledMethod*)caller.cb())->method()->is_continuation_enter_intrinsic())) {
 
     address pc = caller.pc();
 


### PR DESCRIPTION
This pull request contains a backport of commit [8e4240c3](https://github.com/openjdk/jdk/commit/8e4240c3167ff6c803f3391f70ef9cfa7f408085) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Patricio Chilano Mateo on 24 Aug 2023 and was reviewed by Ron Pressler and Andrew Haley.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314850](https://bugs.openjdk.org/browse/JDK-8314850): SharedRuntime::handle_wrong_method() gets called too often when resolving Continuation.enter (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/100.diff">https://git.openjdk.org/jdk21u/pull/100.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/100#issuecomment-1692295927)