### PR TITLE
8312585: Rename DisableTHPStackMitigation flag to THPStackMitigation

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -89,10 +89,10 @@
           "to disable both the override and the printouts."             \
           "See prctl(PR_SET_TIMERSLACK) for more info.")                \
                                                                         \
-  product(bool, DisableTHPStackMitigation, false, DIAGNOSTIC,           \
+  product(bool, THPStackMitigation, true, DIAGNOSTIC,                   \
           "If THPs are unconditionally enabled on the system (mode "    \
           "\"always\"), the JVM will prevent THP from forming in "      \
-          "thread stacks. This switch disables that mitigation and "    \
+          "thread stacks. When disabled, the absence of this mitigation"\
           "allows THPs to form in thread stacks.")                      \
                                                                         \
   develop(bool, DelayThreadStartALot, false,                            \

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -211,7 +211,7 @@ public class THPsInThreadStackPreventionTest {
 
                 // explicitly disable the no-THP-workaround:
                 finalargs.add("-XX:+UnlockDiagnosticVMOptions");
-                finalargs.add("-XX:+DisableTHPStackMitigation");
+                finalargs.add("-XX:-THPStackMitigation");
 
                 finalargs.add(TestMain.class.getName());
                 ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);


### PR DESCRIPTION
Clean backport. 8312182 introduced a mitigation for THP-related RSS bloat; it came with a switch to switch it off. We then decided to rename the switch. Since the switch should be the same across all releases, this needs to be backported too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312585](https://bugs.openjdk.org/browse/JDK-8312585): Rename DisableTHPStackMitigation flag to THPStackMitigation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/105.diff">https://git.openjdk.org/jdk21u/pull/105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/105#issuecomment-1697174679)