### PR TITLE
8309889: [s390] Missing return statement after calling jump_to_native_invoker method in generate_method_handle_dispatch.

### DIFF
--- a/src/hotspot/cpu/s390/methodHandles_s390.cpp
+++ b/src/hotspot/cpu/s390/methodHandles_s390.cpp
@@ -387,6 +387,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
   } else if (iid == vmIntrinsics::_linkToNative) {
     assert(for_compiler_entry, "only compiler entry is supported");
     jump_to_native_invoker(_masm, member_reg, temp1);
+    return;
   }
 
   // The method is a member invoker used by direct method handles.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [514816ed](https://github.com/openjdk/jdk/commit/514816ed7d7dea1fb13d32b80aef89774bee13d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sidraya Jayagond on 4 Jul 2023 and was reviewed by Amit Kumar and Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309889](https://bugs.openjdk.org/browse/JDK-8309889): [s390] Missing return statement after calling jump_to_native_invoker method in generate_method_handle_dispatch. (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/106.diff">https://git.openjdk.org/jdk21u/pull/106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/106#issuecomment-1693733131)