### PR TITLE
8309032: jpackage does not work for module projects unless --module-path is specified

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -24,6 +24,8 @@
  */
 package jdk.jpackage.internal;
 
+import jdk.internal.util.OperatingSystem;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -58,6 +60,10 @@ final class LauncherData {
 
     String qualifiedClassName() {
         return qualifiedClassName;
+    }
+
+    boolean isClassNameFromMainJar() {
+        return jarMainClass != null;
     }
 
     String packageName() {
@@ -209,6 +215,7 @@ final class LauncherData {
                 if (attrs != null) {
                     launcherData.qualifiedClassName = attrs.getValue(
                             Attributes.Name.MAIN_CLASS);
+                    launcherData.jarMainClass = launcherData.qualifiedClassName;
                 }
             }
         }
@@ -307,6 +314,7 @@ final class LauncherData {
     }
 
     private String qualifiedClassName;
+    private String jarMainClass;
     private Path mainJarName;
     private List<Path> classPath;
     private List<Path> modulePath;
@@ -344,7 +352,7 @@ final class LauncherData {
             // of `release` file.
 
             final Path releaseFile;
-            if (!Platform.isMac()) {
+            if (!OperatingSystem.isMacOS()) {
                 releaseFile = cookedRuntime.resolve("release");
             } else {
                 // On Mac `cookedRuntime` can be runtime root or runtime home.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -24,8 +24,6 @@
  */
 package jdk.jpackage.internal;
 
-import jdk.internal.util.OperatingSystem;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -60,10 +58,6 @@ final class LauncherData {
 
     String qualifiedClassName() {
         return qualifiedClassName;
-    }
-
-    boolean isClassNameFromMainJar() {
-        return jarMainClass != null;
     }
 
     String packageName() {
@@ -105,7 +99,7 @@ final class LauncherData {
     }
 
     private void verifyIsModular(boolean isModular) {
-        if ((moduleInfo != null) != isModular) {
+        if ((moduleInfo == null) == isModular) {
             throw new IllegalStateException();
         }
     }
@@ -215,7 +209,6 @@ final class LauncherData {
                 if (attrs != null) {
                     launcherData.qualifiedClassName = attrs.getValue(
                             Attributes.Name.MAIN_CLASS);
-                    launcherData.jarMainClass = launcherData.qualifiedClassName;
                 }
             }
         }
@@ -266,14 +259,10 @@ final class LauncherData {
     private static String getStringParam(Map<String, ? super Object> params,
             String paramName) {
         Optional<Object> value = Optional.ofNullable(params.get(paramName));
-        if (value.isPresent()) {
-            return value.get().toString();
-        }
-        return null;
+        return value.map(Object::toString).orElse(null);
     }
 
-    private static <T> T getPathParam(Map<String, ? super Object> params,
-            String paramName, Supplier<T> func) throws ConfigException {
+    private static <T> T getPathParam(String paramName, Supplier<T> func) throws ConfigException {
         try {
             return func.get();
         } catch (InvalidPathException ex) {
@@ -285,7 +274,7 @@ final class LauncherData {
 
     private static Path getPathParam(Map<String, ? super Object> params,
             String paramName) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
+        return getPathParam(paramName, () -> {
             String value = getStringParam(params, paramName);
             Path result = null;
             if (value != null) {
@@ -304,7 +293,7 @@ final class LauncherData {
             runtimePath = runtimePath.resolve("lib");
             modulePath = Stream.of(modulePath, List.of(runtimePath))
                     .flatMap(List::stream)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
         }
 
         return modulePath;
@@ -312,17 +301,12 @@ final class LauncherData {
 
     private static List<Path> getPathListParameter(String paramName,
             Map<String, ? super Object> params) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
-            String value = (String) params.get(paramName);
-            return (value == null) ? List.of() :
-                    List.of(value.split(File.pathSeparator)).stream()
-                    .map(Path::of)
-                    .collect(Collectors.toUnmodifiableList());
-        });
+        return getPathParam(paramName, () ->
+                params.get(paramName) instanceof String value ?
+                        Stream.of(value.split(File.pathSeparator)).map(Path::of).toList() : List.of());
     }
 
     private String qualifiedClassName;
-    private String jarMainClass;
     private Path mainJarName;
     private List<Path> classPath;
     private List<Path> modulePath;
@@ -360,7 +344,7 @@ final class LauncherData {
             // of `release` file.
 
             final Path releaseFile;
-            if (!OperatingSystem.isMacOS()) {
+            if (!Platform.isMac()) {
                 releaseFile = cookedRuntime.resolve("release");
             } else {
                 // On Mac `cookedRuntime` can be runtime root or runtime home.


### PR DESCRIPTION
Fixes an error when trying to add additional launchers in jpackage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032): jpackage does not work for module projects unless --module-path is specified (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/120.diff">https://git.openjdk.org/jdk21u/pull/120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/120#issuecomment-1702091903)