### PR TITLE
8315206: RISC-V: hwprobe query is_set return wrong value

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -100,7 +100,7 @@ static bool is_valid(int64_t key) {
 
 static bool is_set(int64_t key, uint64_t value_mask) {
   if (is_valid(key)) {
-    return query[key].value & value_mask != 0;
+    return (query[key].value & value_mask) != 0;
   }
   return false;
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [876a725a](https://github.com/openjdk/jdk/commit/876a725af95d65d59390c86bfec64c33cccbf53b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on 30 Aug 2023 and was reviewed by Ludovic Henry and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315206](https://bugs.openjdk.org/browse/JDK-8315206): RISC-V: hwprobe query is_set return wrong value (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/121.diff">https://git.openjdk.org/jdk21u/pull/121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/121#issuecomment-1702147940)