### PR TITLE
8313323: javac -g on a java file which uses unnamed variable leads to ClassFormatError when launching that class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -2189,6 +2189,8 @@ public class Code {
                 ((var.sym.owner.flags() & Flags.LAMBDA_METHOD) == 0 ||
                  (var.sym.flags() & Flags.PARAMETER) == 0);
         if (ignoredSyntheticVar) return;
+        //don't include unnamed variables:
+        if (var.sym.name == var.sym.name.table.names.empty) return ;
         if (varBuffer == null)
             varBuffer = new LocalVar[20];
         else

--- a/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
+++ b/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8313323
+ * @summary Verify javac does not produce incorrect LocalVariableTable
+ * @enablePreview
+ * @compile -g UnnamedLocalVariableTable.java
+ * @run main UnnamedLocalVariableTable
+ */
+public class UnnamedLocalVariableTable {
+    public static void main(String... args) {
+        try {
+            int _ = 0;
+            if (args[0] instanceof String _) {
+                System.err.println("1");
+            }
+            I i = _ -> {};
+            java.util.List<String> _ = null;
+        } catch (Exception _) {
+            System.err.println("2");
+        }
+    }
+
+    interface I {
+        public void test(String s);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [adfc1d6c](https://github.com/openjdk/jdk/commit/adfc1d6cd29181c729030d4cbafc8ecf349abab9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 4 Sep 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313323](https://bugs.openjdk.org/browse/JDK-8313323): javac -g on a java file which uses unnamed variable leads to ClassFormatError when launching that class (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/128.diff">https://git.openjdk.org/jdk21u/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/128#issuecomment-1704916847)