### PR TITLE
8310618: Test serviceability/sa/ClhsdbDumpclass.java fails after 8242152: 'StackMapTable:' missing from stdout/stderr

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
@@ -62,6 +62,7 @@ public class ConstMethod extends Metadata {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type                  = db.lookupType("ConstMethod");
     constants                  = new MetadataField(type.getAddressField("_constants"), 0);
+    stackMapData               = type.getAddressField("_stackmap_data");
     constMethodSize            = new CIntField(type.getCIntegerField("_constMethod_size"), 0);
     flags                      = new CIntField(type.getCIntegerField("_flags._flags"), 0);
 
@@ -108,6 +109,7 @@ public class ConstMethod extends Metadata {
 
   // Fields
   private static MetadataField constants;
+  private static AddressField stackMapData; // Raw stackmap data for the method (#entries + entries)
   private static CIntField constMethodSize;
   private static CIntField flags;
   private static CIntField codeSize;
@@ -134,6 +136,15 @@ public class ConstMethod extends Metadata {
   // Accessors for declared fields
   public ConstantPool getConstants() {
     return (ConstantPool) constants.getValue(this);
+  }
+
+  public boolean hasStackMapTable() {
+    return stackMapData.getValue(getAddress()) != null;
+  }
+
+  public U1Array getStackMapData() {
+    Address addr = stackMapData.getValue(getAddress());
+    return VMObjectFactory.newObject(U1Array.class, addr);
   }
 
   public long getConstMethodSize() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
@@ -27,6 +27,7 @@ package sun.jvm.hotspot.oops;
 import java.io.PrintStream;
 import sun.jvm.hotspot.utilities.Observable;
 import sun.jvm.hotspot.utilities.Observer;
+import sun.jvm.hotspot.utilities.U1Array;
 
 import sun.jvm.hotspot.code.NMethod;
 import sun.jvm.hotspot.debugger.Address;
@@ -117,6 +118,12 @@ public class Method extends Metadata {
   }
   public ConstantPool getConstants()                  {
     return getConstMethod().getConstants();
+  }
+  public boolean      hasStackMapTable()              {
+    return getConstMethod().hasStackMapTable();
+  }
+  public U1Array      getStackMapData()               {
+    return getConstMethod().getStackMapData();
   }
   public MethodData   getMethodData()                 {
     Address addr = methodData.getValue(getAddress());

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -75,6 +75,8 @@ public class ClhsdbDumpclass {
             // Run javap on the generated class file to make sure it's valid.
             JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("javap");
             launcher.addVMArgs(Utils.getTestJavaOpts());
+            // Let javap print additional info, e.g., StackMapTable
+            launcher.addToolArg("-verbose");
             launcher.addToolArg(classFile.toString());
             System.out.println("> javap " + classFile.toString());
             List<String> cmdStringList = Arrays.asList(launcher.getCommand());

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -86,6 +86,10 @@ public class ClhsdbDumpclass {
             System.err.println(out.getStderr());
             out.shouldHaveExitValue(0);
             out.shouldMatch("public class " + APP_DOT_CLASSNAME);
+            // StackMapTable might not be generated for a class
+            // containing only methods with sequential control flows.
+            // But the class used here (LingeredApp) is not such a case.
+            out.shouldContain("StackMapTable:");
             out.shouldNotContain("Error:");
         } catch (SkippedException se) {
             throw se;


### PR DESCRIPTION
Clean backport.
Tests in "serviceability/sa" run locallly on Linux (because of GHA skips these tests on Linux with SkippedException) - passed.

NOTE that this is a PR chain, the previous PR is #129.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8310618](https://bugs.openjdk.org/browse/JDK-8310618) needs maintainer approval

### Issue
 * [JDK-8310618](https://bugs.openjdk.org/browse/JDK-8310618): Test serviceability/sa/ClhsdbDumpclass.java fails after 8242152: 'StackMapTable:' missing from stdout/stderr (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/130.diff">https://git.openjdk.org/jdk21u/pull/130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/130#issuecomment-1704959652)