### PR TITLE
8311938: Add default cups include location for configure on AIX

### DIFF
--- a/make/autoconf/lib-cups.m4
+++ b/make/autoconf/lib-cups.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,12 +68,20 @@ AC_DEFUN_ONCE([LIB_SETUP_CUPS],
       fi
     fi
     if test "x$CUPS_FOUND" = xno; then
-      # Are the cups headers installed in the default /usr/include location?
-      AC_CHECK_HEADERS([cups/cups.h cups/ppd.h], [
-          CUPS_FOUND=yes
-          CUPS_CFLAGS=
-          DEFAULT_CUPS=yes
-      ])
+      # Are the cups headers installed in the default AIX or /usr/include location?
+      if test "x$OPENJDK_TARGET_OS" = "xaix"; then
+        AC_CHECK_HEADERS([/opt/freeware/include/cups/cups.h /opt/freeware/include/cups/ppd.h], [
+            CUPS_FOUND=yes
+            CUPS_CFLAGS="-I/opt/freeware/include"
+            DEFAULT_CUPS=yes
+        ])
+      else
+        AC_CHECK_HEADERS([cups/cups.h cups/ppd.h], [
+            CUPS_FOUND=yes
+            CUPS_CFLAGS=
+            DEFAULT_CUPS=yes
+        ])
+      fi
     fi
     if test "x$CUPS_FOUND" = xno; then
       HELP_MSG_MISSING_DEPENDENCY([cups])


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311938](https://bugs.openjdk.org/browse/JDK-8311938) needs maintainer approval

### Issue
 * [JDK-8311938](https://bugs.openjdk.org/browse/JDK-8311938): Add default cups include location for configure on AIX (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/138.diff">https://git.openjdk.org/jdk21u/pull/138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/138#issuecomment-1706787832)