### PR TITLE
Backport 489a32fe40e2a2c539296d51d4ffc0abc036d33c

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -78,6 +78,7 @@ void PhiResolverState::reset() {
 PhiResolver::PhiResolver(LIRGenerator* gen)
  : _gen(gen)
  , _state(gen->resolver_state())
+ , _loop(nullptr)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays


### PR DESCRIPTION
[JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813)

Initialize `PhiResolver::_loop` field to `nullptr`

Clean backport