### PR TITLE
8312466: /bin/nm  usage in AIX makes needs -X64 flag

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -273,6 +273,12 @@ ifneq ($(GENERATE_COMPILE_COMMANDS_ONLY), true)
         #
     UNDEF_PATTERN := ' U '
 
+    # 'nm' on AIX needs -X64 option
+
+    ifeq ($(call isTargetOs, aix), true)
+      NM := $(NM) -X64
+    endif
+
     define SetupOperatorNewDeleteCheck
         $1.op_check: $1
 	  $$(call ExecuteWithLog, $1.op_check, \


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312466](https://bugs.openjdk.org/browse/JDK-8312466) needs maintainer approval

### Issue
 * [JDK-8312466](https://bugs.openjdk.org/browse/JDK-8312466): /bin/nm  usage in AIX makes needs -X64 flag (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/145.diff">https://git.openjdk.org/jdk21u/pull/145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/145#issuecomment-1711212208)