### PR TITLE
8313873: java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  fails on AIX due to small default RCVBUF size and different IPv6 Header interpretation

### DIFF
--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 package jdk.test.lib.net;
+
+import jdk.test.lib.Platform;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -48,6 +50,9 @@ public class IPSupport {
     private static final boolean hasIPv6;
     private static final boolean preferIPv4Stack;
     private static final boolean preferIPv6Addresses;
+    private static final int IPV4_SNDBUF = 65507;
+    private static final int IPV6_SNDBUF = 65527;
+    private static final int IPV6_SNDBUF_AIX = 65487;
 
     static {
         hasIPv4 = runPrivilegedAction(() -> isSupported(Inet4Address.class));
@@ -111,7 +116,6 @@ public class IPSupport {
         return preferIPv6Addresses;
     }
 
-
     /**
      * Whether or not the current networking configuration is valid or not.
      *
@@ -154,4 +158,21 @@ public class IPSupport {
         out.println("preferIPv6Addresses: " + preferIPv6Addresses());
     }
 
+    /**
+     * Return current platform's maximum size for IPv4 UDP send buffer
+     */
+    public static final int getMaxUDPSendBufSizeIPv4() {
+        return IPV4_SNDBUF;
+    }
+
+    /**
+     * Return current platform's maximum size for IPv6 UDP send buffer
+     */
+    public static final int getMaxUDPSendBufSizeIPv6() {
+        if (Platform.isAix()) {
+            return IPV6_SNDBUF_AIX;
+        } else {
+            return IPV6_SNDBUF;
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [486fa08d](https://github.com/openjdk/jdk/commit/486fa08d4b22243443d39efa34c78d7e9eb44775) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Obermeier on 31 Aug 2023 and was reviewed by Christoph Langer and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8313873](https://bugs.openjdk.org/browse/JDK-8313873) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313873](https://bugs.openjdk.org/browse/JDK-8313873): java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  fails on AIX due to small default RCVBUF size and different IPv6 Header interpretation (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/155.diff">https://git.openjdk.org/jdk21u/pull/155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/155#issuecomment-1715803179)