### PR TITLE
8316113: Infinite permission checking loop in java/net/spi/InetAddressResolverProvider/RuntimePermissionTest

### DIFF
--- a/test/jdk/java/net/spi/InetAddressResolverProvider/RuntimePermissionTest.java
+++ b/test/jdk/java/net/spi/InetAddressResolverProvider/RuntimePermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class RuntimePermissionTest {
                 ServiceConfigurationError sce =
                         Assert.expectThrows(ServiceConfigurationError.class,
                                             () -> InetAddress.getByName("javaTest.org"));
-                LOGGER.info("Got ServiceConfigurationError: " + sce);
+                System.err.println("Got ServiceConfigurationError: " + sce);
                 Throwable cause = sce.getCause();
                 Assert.assertTrue(cause instanceof SecurityException);
                 Assert.assertTrue(cause.getMessage().contains(RUNTIME_PERMISSION_NAME));
@@ -78,23 +78,25 @@ public class RuntimePermissionTest {
 
         public TestSecurityManager(boolean permitInetAddressResolver) {
             this.permitInetAddressResolver = permitInetAddressResolver;
-            LOGGER.info("inetAddressResolverProvider permission is " +
-                        (permitInetAddressResolver ? "granted" : "not granted"));
+            System.err.println("inetAddressResolverProvider permission is " +
+                               (permitInetAddressResolver ? "granted" : "not granted"));
         }
 
         @Override
         public void checkPermission(Permission permission) {
             if (permission instanceof RuntimePermission) {
-                LOGGER.info("Checking RuntimePermission: " + permission);
                 if (RUNTIME_PERMISSION_NAME.equals(permission.getName()) && !permitInetAddressResolver) {
-                    LOGGER.info("Denying '" + RUNTIME_PERMISSION_NAME + "' permission");
+                    System.err.println("Denying '" + RUNTIME_PERMISSION_NAME + "' permission");
                     throw new SecurityException("Access Denied: " + RUNTIME_PERMISSION_NAME);
-                }
+                } else {
+                   // Do not do anything for non-matching Permission. Otherwise the test
+                   // has a chance to re-enter here recursively, e.g. due to permission
+                   // checks during class load. This would eventually overflow the stack.
+               }
             }
         }
     }
 
     private static final String RUNTIME_PERMISSION_NAME = "inetAddressResolverProvider";
-    private static final Logger LOGGER = Logger.getLogger(RuntimePermissionTest.class.getName());
 
 }


### PR DESCRIPTION
Clean backport to fix intermittent test failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316113](https://bugs.openjdk.org/browse/JDK-8316113) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316113](https://bugs.openjdk.org/browse/JDK-8316113): Infinite permission checking loop in java/net/spi/InetAddressResolverProvider/RuntimePermissionTest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/156.diff">https://git.openjdk.org/jdk21u/pull/156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/156#issuecomment-1717104965)