### PR TITLE
8315579: SPARC64 builds are broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -52,7 +52,8 @@ public enum Architecture {
     PPC64(64, ByteOrder.BIG_ENDIAN),
     PPC64LE(64, ByteOrder.LITTLE_ENDIAN),
     MIPSEL(32, ByteOrder.LITTLE_ENDIAN),
-    MIPS64EL(64, ByteOrder.LITTLE_ENDIAN)
+    MIPS64EL(64, ByteOrder.LITTLE_ENDIAN),
+    SPARCV9(64, ByteOrder.BIG_ENDIAN),
     ;
 
     private final int addrSize;
@@ -200,6 +201,14 @@ public enum Architecture {
     @ForceInline
     public static boolean isMIPS64EL() {
         return PlatformProps.TARGET_ARCH_IS_MIPS64EL;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is SPARCV9}
+     */
+    @ForceInline
+    public static boolean isSPARCV9() {
+        return PlatformProps.TARGET_ARCH_IS_SPARCV9;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -63,4 +63,5 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_PPC64LE = "@@OPENJDK_TARGET_CPU@@" == "ppc64le";
     static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";
     static final boolean TARGET_ARCH_IS_MIPS64EL= "@@OPENJDK_TARGET_CPU@@" == "mips64el";
+    static final boolean TARGET_ARCH_IS_SPARCV9 = "@@OPENJDK_TARGET_CPU@@" == "sparcv9";
 }

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -39,6 +39,7 @@ import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
 import static jdk.internal.util.Architecture.MIPSEL;
 import static jdk.internal.util.Architecture.MIPS64EL;
+import static jdk.internal.util.Architecture.SPARCV9;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,6 +86,7 @@ public class ArchTest {
                 Arguments.of("riscv64", RISCV64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isRISCV64()),
                 Arguments.of("s390", S390, 64, ByteOrder.BIG_ENDIAN, Architecture.isS390()),
                 Arguments.of("s390x", S390, 64, ByteOrder.BIG_ENDIAN, Architecture.isS390()),
+                Arguments.of("sparcv9", SPARCV9, 64, ByteOrder.BIG_ENDIAN, Architecture.isSPARCV9()),
                 Arguments.of("x64", X64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isX64()),
                 Arguments.of("x86", X86, 32, ByteOrder.LITTLE_ENDIAN, Architecture.isX86()),
                 Arguments.of("x86_64", X64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isX64())


### PR DESCRIPTION
Clean backport to unbreak another architecture.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315579](https://bugs.openjdk.org/browse/JDK-8315579) needs maintainer approval

### Issue
 * [JDK-8315579](https://bugs.openjdk.org/browse/JDK-8315579): SPARC64 builds are broken after JDK-8304913 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/158.diff">https://git.openjdk.org/jdk21u/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/158#issuecomment-1717812019)