### PR TITLE
8311514: Incorrect regex in TestMetaSpaceLog.java

### DIFF
--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -58,7 +58,13 @@ public class TestMetaSpaceLog {
     // Do this once here.
     // Scan for Metaspace update notices as part of the GC log, e.g. in this form:
     // [gc,metaspace   ] GC(0) Metaspace: 11895K(14208K)->11895K(14208K) NonClass: 10552K(12544K)->10552K(12544K) Class: 1343K(1664K)->1343K(1664K)
-    metaSpaceRegexp = Pattern.compile(".*Metaspace: ([0-9]+).*->([0-9]+).*");
+    // This regex has to be up-to-date with the format used in hotspot to print metaspace change.
+    final String NUM_K = "\\d+K";
+    final String GP_NUM_K = "(\\d+)K";
+    final String BR_NUM_K = "\\(" + NUM_K + "\\)";
+    final String SIZE_CHG = NUM_K + BR_NUM_K + "->" + NUM_K + BR_NUM_K;
+    metaSpaceRegexp = Pattern.compile(".* Metaspace: " + GP_NUM_K + BR_NUM_K + "->" + GP_NUM_K + BR_NUM_K
+                                      + "( NonClass: " + SIZE_CHG + " Class: " + SIZE_CHG + ")?$");
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Clean backport to fix the regex in jtreg test TestMetaSpaceLog.java capturing wrong value which might cause this test to always pass. 

[JDK-8311514](https://bugs.openjdk.org/browse/JDK-8311514)Incorrect regex in TestMetaSpaceLog.java

Tested with GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311514](https://bugs.openjdk.org/browse/JDK-8311514) needs maintainer approval

### Issue
 * [JDK-8311514](https://bugs.openjdk.org/browse/JDK-8311514): Incorrect regex in TestMetaSpaceLog.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/159.diff">https://git.openjdk.org/jdk21u/pull/159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/159#issuecomment-1717826424)