### PR TITLE
8314632: Intra-case dominance check fails in the presence of a guard

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4712,7 +4712,7 @@ public class Check {
                                          TreeInfo.unguardedCase(testCase);
                         } else if (label instanceof JCPatternCaseLabel patternCL &&
                                    testCaseLabel instanceof JCPatternCaseLabel testPatternCaseLabel &&
-                                   TreeInfo.unguardedCase(testCase)) {
+                                   (testCase.equals(c) || TreeInfo.unguardedCase(testCase))) {
                             dominated = patternDominated(testPatternCaseLabel.pat,
                                                          patternCL.pat);
                         }

--- a/test/langtools/tools/javac/patterns/T8314632.java
+++ b/test/langtools/tools/javac/patterns/T8314632.java
@@ -1,0 +1,40 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8314632
+ * @summary Intra-case dominance check fails in the presence of a guard
+ * @enablePreview
+ * @compile/fail/ref=T8314632.out -XDrawDiagnostics T8314632.java
+ */
+public class T8314632 {
+    void test1(Object obj) {
+        switch (obj) {
+            case Float _ -> {}
+            case Integer _, CharSequence _, String _ when obj.hashCode() > 0 -> { } // error
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+
+    void test2(Object obj) {
+        switch (obj) {
+            case Float _ -> {}
+            case Integer _, CharSequence _, String _ -> { }
+            default -> throw new IllegalStateException("Unexpected value: " + obj); // error
+        }
+    }
+
+    void test3(Object obj) {
+        switch (obj) {
+            case Float _, CharSequence _ when obj.hashCode() > 0 -> { } // OK
+            case Integer _, String _     when obj.hashCode() > 0 -> { } // OK, since the previous case is guarded
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+
+    void test4(Object obj) {
+        switch (obj) {
+            case Float _, CharSequence _ -> { } // OK
+            case Integer _, String _     when obj.hashCode() > 0 -> { } // error, since the previous case is unguarded
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8314632.out
+++ b/test/langtools/tools/javac/patterns/T8314632.out
@@ -1,0 +1,6 @@
+T8314632.java:12:45: compiler.err.pattern.dominated
+T8314632.java:20:45: compiler.err.pattern.dominated
+T8314632.java:36:29: compiler.err.pattern.dominated
+- compiler.note.preview.filename: T8314632.java, DEFAULT
+- compiler.note.preview.recompile
+3 errors


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314632](https://bugs.openjdk.org/browse/JDK-8314632) needs maintainer approval

### Issue
 * [JDK-8314632](https://bugs.openjdk.org/browse/JDK-8314632): Intra-case dominance check fails in the presence of a guard (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/162.diff">https://git.openjdk.org/jdk21u/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/162#issuecomment-1720870425)