### PR TITLE
8309545: Thread.interrupted from virtual thread needlessly resets interrupt status

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -864,13 +864,14 @@ final class VirtualThread extends BaseVirtualThread {
     @Override
     boolean getAndClearInterrupt() {
         assert Thread.currentThread() == this;
-        synchronized (interruptLock) {
-            boolean oldValue = interrupted;
-            if (oldValue)
+        boolean oldValue = interrupted;
+        if (oldValue) {
+            synchronized (interruptLock) {
                 interrupted = false;
-            carrierThread.clearInterrupt();
-            return oldValue;
+                carrierThread.clearInterrupt();
+            }
         }
+        return oldValue;
     }
 
     @Override


### PR DESCRIPTION
backport 8309545

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309545](https://bugs.openjdk.org/browse/JDK-8309545) needs maintainer approval

### Issue
 * [JDK-8309545](https://bugs.openjdk.org/browse/JDK-8309545): Thread.interrupted from virtual thread needlessly resets interrupt status (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/166.diff">https://git.openjdk.org/jdk21u/pull/166.diff</a>

</details>
