### PR TITLE
8312166: (dc) DatagramChannel's socket adaptor does not release carrier thread when blocking in receive

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -44,7 +43,6 @@ import java.net.SocketException;
 import java.net.SocketOption;
 import java.net.SocketTimeoutException;
 import java.net.StandardSocketOptions;
-import java.nio.ByteBuffer;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ClosedByInterruptException;
@@ -56,7 +54,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
-import jdk.internal.misc.Blocker;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -192,79 +189,30 @@ public class DatagramSocketAdaptor
 
     @Override
     public void send(DatagramPacket p) throws IOException {
-        synchronized (p) {
-            int len = p.getLength();
-            ByteBuffer bb = Util.getTemporaryDirectBuffer(len);
-            try {
-                // copy bytes to temporary direct buffer
-                bb.put(p.getData(), p.getOffset(), len);
-                bb.flip();
-
-                // target address
-                InetSocketAddress target;
-                if (p.getAddress() == null) {
-                    InetSocketAddress remote = dc.remoteAddress();
-                    if (remote == null) {
-                        // not specified by DatagramSocket
-                        throw new IllegalArgumentException("Address not set");
-                    }
-                    // set address/port to maintain compatibility with DatagramSocket
-                    p.setAddress(remote.getAddress());
-                    p.setPort(remote.getPort());
-                    target = remote;
-                } else {
-                    target = (InetSocketAddress) p.getSocketAddress();
-                }
-
-                // send datagram
-                dc.blockingSend(bb, target);
-            } catch (AlreadyConnectedException e) {
-                throw new IllegalArgumentException("Connected and packet address differ");
-            } catch (ClosedChannelException e) {
-                throw new SocketException("Socket closed", e);
-            } finally {
-                Util.offerFirstTemporaryDirectBuffer(bb);
-            }
+        try {
+            dc.blockingSend(p);
+        } catch (AlreadyConnectedException e) {
+            throw new IllegalArgumentException("Connected and packet address differ");
+        } catch (ClosedChannelException e) {
+            throw new SocketException("Socket closed", e);
         }
     }
 
     @Override
     public void receive(DatagramPacket p) throws IOException {
-        synchronized (p) {
-            // get temporary direct buffer with a capacity of p.bufLength
-            int bufLength = DatagramPackets.getBufLength(p);
-            ByteBuffer bb = Util.getTemporaryDirectBuffer(bufLength);
-            try {
-                SocketAddress sender;
-                long comp = Blocker.begin();
-                try {
-                    sender = dc.blockingReceive(bb, MILLISECONDS.toNanos(timeout));
-                } finally {
-                    Blocker.end(comp);
-                }
-                bb.flip();
-
-                // copy bytes to the DatagramPacket and set length
-                int len = Math.min(bb.limit(), DatagramPackets.getBufLength(p));
-                bb.get(p.getData(), p.getOffset(), len);
-                DatagramPackets.setLength(p, len);
-
-                // sender address
-                p.setSocketAddress(sender);
-            } catch (SocketTimeoutException | ClosedByInterruptException e) {
-                throw e;
-            } catch (InterruptedIOException e) {
-                Thread thread = Thread.currentThread();
-                if (thread.isVirtual() && thread.isInterrupted()) {
-                    close();
-                    throw new SocketException("Closed by interrupt");
-                }
-                throw e;
-            } catch (ClosedChannelException e) {
-                throw new SocketException("Socket closed", e);
-            } finally {
-                Util.offerFirstTemporaryDirectBuffer(bb);
+        try {
+            dc.blockingReceive(p, MILLISECONDS.toNanos(timeout));
+        } catch (SocketTimeoutException | ClosedByInterruptException e) {
+            throw e;
+        } catch (InterruptedIOException e) {
+            Thread thread = Thread.currentThread();
+            if (thread.isVirtual() && thread.isInterrupted()) {
+                close();
+                throw new SocketException("Closed by interrupt");
             }
+            throw e;
+        } catch (ClosedChannelException e) {
+            throw new SocketException("Socket closed", e);
         }
     }
 
@@ -702,44 +650,6 @@ public class DatagramSocketAdaptor
      */
     private InetAddress anyInetAddress() {
         return new InetSocketAddress(0).getAddress();
-    }
-
-    /**
-     * Defines static methods to get/set DatagramPacket fields and workaround
-     * DatagramPacket deficiencies.
-     */
-    private static class DatagramPackets {
-        private static final VarHandle LENGTH;
-        private static final VarHandle BUF_LENGTH;
-        static {
-            try {
-                PrivilegedExceptionAction<MethodHandles.Lookup> pa = () ->
-                    MethodHandles.privateLookupIn(DatagramPacket.class, MethodHandles.lookup());
-                @SuppressWarnings("removal")
-                MethodHandles.Lookup l = AccessController.doPrivileged(pa);
-                LENGTH = l.findVarHandle(DatagramPacket.class, "length", int.class);
-                BUF_LENGTH = l.findVarHandle(DatagramPacket.class, "bufLength", int.class);
-            } catch (Exception e) {
-                throw new ExceptionInInitializerError(e);
-            }
-        }
-
-        /**
-         * Sets the DatagramPacket.length field. DatagramPacket.setLength cannot be
-         * used at this time because it sets both the length and bufLength fields.
-         */
-        static void setLength(DatagramPacket p, int value) {
-            assert Thread.holdsLock(p);
-            LENGTH.set(p, value);
-        }
-
-        /**
-         * Returns the value of the DatagramPacket.bufLength field.
-         */
-        static int getBufLength(DatagramPacket p) {
-            assert Thread.holdsLock(p);
-            return (int) BUF_LENGTH.get(p);
-        }
     }
 
     /**

--- a/test/jdk/java/net/DatagramSocket/TimeoutWithSM.java
+++ b/test/jdk/java/net/DatagramSocket/TimeoutWithSM.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test a timed DatagramSocket.receive with a SecurityManager set
+ * @run main/othervm -Djava.security.manager=allow TimeoutWithSM
+ */
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
+import java.security.Permission;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TimeoutWithSM {
+
+    private static final int TIMEOUT = 10_000;
+
+    public static void main(String[] args) throws Exception {
+        try (var socket = new DatagramSocket(null)) {
+            InetAddress lb = InetAddress.getLoopbackAddress();
+            socket.bind(new InetSocketAddress(lb, 0));
+
+            // start sender to send datagrams to us
+            var done = new AtomicBoolean();
+            startSender(socket.getLocalSocketAddress(), done);
+
+            // set a SecurityManager that blocks datagrams from sender
+            System.setSecurityManager(new SecurityManager() {
+                @Override
+                public void checkPermission(Permission p) {
+                }
+                @Override
+                public void checkAccept(String host, int port) {
+                    var isa = new InetSocketAddress(host, port);
+                    System.out.println("checkAccept " + isa);
+                    throw new SecurityException();
+                }
+            });
+
+            // timed receive, should throw SocketTimeoutException
+            try {
+                socket.setSoTimeout(TIMEOUT);
+                try {
+                    byte[] bytes = new byte[1024];
+                    DatagramPacket p = new DatagramPacket(bytes, bytes.length);
+                    socket.receive(p);
+                    throw new RuntimeException("Packet received, unexpected!!! "
+                            + " sender=" + p.getSocketAddress() + ", len=" + p.getLength());
+                } catch (SocketTimeoutException expected) {
+                    System.out.println(expected + ", expected!!!");
+                }
+            } finally {
+                done.set(true);
+            }
+        }
+    }
+
+    /**
+     * Start a thread to send datagrams to the given target address at intervals of
+     * one second. The sender stops when done is set to true.
+     */
+    static void startSender(SocketAddress target, AtomicBoolean done) throws Exception {
+        assert target instanceof InetSocketAddress isa && isa.getAddress().isLoopbackAddress();
+        var sender = new DatagramSocket(null);
+        boolean started = false;
+        try {
+            InetAddress lb = InetAddress.getLoopbackAddress();
+            sender.bind(new InetSocketAddress(lb, 0));
+            Thread.ofPlatform().start(() -> {
+                try {
+                    try (sender) {
+                        byte[] bytes = "hello".getBytes("UTF-8");
+                        DatagramPacket p = new DatagramPacket(bytes, bytes.length);
+                        p.setSocketAddress(target);
+                        while (!done.get()) {
+                            System.out.println("Send datagram to " + target + " ...");
+                            sender.send(p);
+                            Thread.sleep(Duration.ofSeconds(1));
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            started = true;
+        } finally {
+            if (!started) {
+                sender.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
backport 8312166

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312166](https://bugs.openjdk.org/browse/JDK-8312166) needs maintainer approval

### Issue
 * [JDK-8312166](https://bugs.openjdk.org/browse/JDK-8312166): (dc) DatagramChannel's socket adaptor does not release carrier thread when blocking in receive (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/167.diff">https://git.openjdk.org/jdk21u/pull/167.diff</a>

</details>
