### PR TITLE
8316031: SSLFlowDelegate should not log from synchronized block

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -971,10 +971,12 @@ public class SSLFlowDelegate {
 
     boolean stopped;
 
-    private synchronized void normalStop() {
-        if (stopped)
-            return;
-        stopped = true;
+    private void normalStop() {
+        synchronized (this) {
+            if (stopped)
+                return;
+            stopped = true;
+        }
         reader.stop();
         writer.stop();
         // make sure the alpnCF is completed.

--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -54,7 +54,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @test
  * @summary Tests HttpClient usage when configured with a local address to bind
  *          to, when sending requests
- * @bug 8209137
+ * @bug 8209137 8316031
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  *
  * @build jdk.test.lib.net.SimpleSSLContext jdk.test.lib.net.IPSupport


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [dc5ca1d3](https://urldefense.com/v3/__https://github.com/openjdk/jdk/commit/dc5ca1d3798727fd29a6a40e9f7777cb7f85c004__;!!ACWV5N9M2RV99hQ!LQ0pZvkfxVjWFGxT56H4vhWDMpHSU7sXkopR0eQ02tdWFkP3QUgJ_HaXrn-rnfoyCxfTiQ9ipwQtjfgDsmkImBvO9tQ$) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Daniel Fuchs on 15 Sep 2023 and was reviewed by Daniel Jeliński.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316031](https://bugs.openjdk.org/browse/JDK-8316031) needs maintainer approval

### Issue
 * [JDK-8316031](https://bugs.openjdk.org/browse/JDK-8316031): SSLFlowDelegate should not log from synchronized block (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/171.diff">https://git.openjdk.org/jdk21u/pull/171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/171#issuecomment-1723989186)