### PR TITLE
8315696: SignedLoggerFinderTest.java test failed

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
@@ -26,12 +26,11 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
- * @modules java.base/sun.util.logging
- * @library /test/lib
+ * @modules java.base/sun.util.logging java.base/jdk.internal.logger:+open
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm PlatformRecursiveLoadingTest
  */
-
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -50,6 +49,8 @@ public class PlatformRecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         PlatformLogger.getLogger("main").info("in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
@@ -26,6 +26,8 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
+ * @modules java.base/jdk.internal.logger:+open
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm RecursiveLoadingTest
  */
@@ -45,6 +47,8 @@ public class RecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         System.getLogger("main").log(System.Logger.Level.INFO, "in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8314263
  * @summary Signed jars triggering Logger finder recursion and StackOverflowError
- * @library /test/lib
+ * @modules java.base/jdk.internal.logger:+open
+ * @library /test/lib ../lib
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.*
  *        jdk.test.lib.util.JarUtils
@@ -146,6 +147,8 @@ public class SignedLoggerFinderTest {
 
             // LoggerFinder should be initialized, trigger a simple log call
             Security.setProperty("test_2", "test");
+            // allow time to let bootstrap logger flush data
+            BootstrapLoggerUtils.awaitPending();
         }
     }
 
@@ -165,6 +168,8 @@ public class SignedLoggerFinderTest {
                 System.getProperty("test.classes")));
         }
         cmds.addAll(List.of(
+            // allow test to access internal bootstrap logger functionality
+            "--add-opens=java.base/jdk.internal.logger=ALL-UNNAMED",
             // following debug property seems useful to tickle the issue
             "-Dsun.misc.URLClassPath.debug=true",
             // console logger level to capture event output

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.Set;
+
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
 
@@ -38,9 +38,10 @@ import jdk.internal.logger.LazyLoggers;
  * @bug     8144460 8144214
  * @summary Cover the logXX and LogEvent.valueOf APIs of BootstrapLogger
  *          and logXX APIs of SimpleConsoleLogger.
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.base/sun.util.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerAPIsTest
  */
 

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,10 @@ import jdk.internal.logger.LazyLoggers;
  * @summary JDK implementation specific unit test for JDK internal artifacts.
             Tests the behavior of bootstrap loggers (and SimpleConsoleLoggers
  *          too).
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerTest NO_SECURITY
  * @run main/othervm -Djava.security.manager=allow BootstrapLoggerTest SECURE
  * @run main/othervm/timeout=120 -Djava.security.manager=allow BootstrapLoggerTest SECURE_AND_WAIT

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-
-import jdk.internal.logger.BootstrapLogger;
 
 /**
  * We use an instance of this class to check what the logging system has printed

--- a/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
+++ b/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.util.function.BooleanSupplier;
 
 import jdk.internal.logger.BootstrapLogger;
 
-class BootstrapLoggerUtils {
+public final class BootstrapLoggerUtils {
 
     private static final Field IS_BOOTED;
     private static final Method AWAIT_PENDING;
@@ -46,11 +46,11 @@ class BootstrapLoggerUtils {
         }
     }
 
-    static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
+    public static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
         IS_BOOTED.set(null, supplier);
     }
 
-    static void awaitPending() {
+    public static void awaitPending() {
         try {
             AWAIT_PENDING.invoke(null);
         } catch (IllegalAccessException | IllegalArgumentException


### PR DESCRIPTION
Test case fix up. Should be a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315696](https://bugs.openjdk.org/browse/JDK-8315696) needs maintainer approval

### Issue
 * [JDK-8315696](https://bugs.openjdk.org/browse/JDK-8315696): SignedLoggerFinderTest.java test failed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/174.diff">https://git.openjdk.org/jdk21u/pull/174.diff</a>

</details>
