### PR TITLE
8314476: TestJstatdPortAndServer.java failed with "java.rmi.NoSuchObjectException: no such object in table"

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -65,6 +65,8 @@ public final class JstatdTest {
     private static final int JSTAT_GCUTIL_INTERVAL_MS = 250;
     private static final String JPS_OUTPUT_REGEX = "^\\d+\\s*.*";
 
+    private static final int MAX_JSTATD_TRIES = 10;
+
     private boolean useDefaultPort = true;
     private boolean useDefaultRmiPort = true;
     private String port;
@@ -282,7 +284,7 @@ public final class JstatdTest {
     private ProcessThread tryToSetupJstatdProcess() throws Throwable {
         portInUse = false;
         ProcessThread jstatdThread = new ProcessThread("Jstatd-Thread",
-                JstatdTest::isJstadReady, getJstatdCmd());
+                JstatdTest::isJstatdReady, getJstatdCmd());
         try {
             jstatdThread.start();
             // Make sure jstatd is up and running
@@ -302,8 +304,8 @@ public final class JstatdTest {
         return jstatdThread;
     }
 
-    private static boolean isJstadReady(String line) {
-        if (line.contains("Port already in use")) {
+    private static boolean isJstatdReady(String line) {
+        if (line.contains("Port already in use") || line.contains("Could not bind")) {
             portInUse = true;
             return true;
         }
@@ -322,8 +324,9 @@ public final class JstatdTest {
         }
 
         ProcessThread jstatdThread = null;
+        int tries = 0;
         try {
-            while (jstatdThread == null) {
+            while (jstatdThread == null && ++tries <= MAX_JSTATD_TRIES) {
                 if (!useDefaultPort) {
                     port = String.valueOf(Utils.getFreePort());
                 }
@@ -339,10 +342,11 @@ public final class JstatdTest {
                         continue;
                     }
                 }
-
                 jstatdThread = tryToSetupJstatdProcess();
             }
-
+            if (jstatdThread == null) {
+                throw new RuntimeException("Cannot start jstatd.");
+            }
             runToolsAndVerify();
         } finally {
             cleanUpThread(jstatdThread);


### PR DESCRIPTION
-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314476](https://bugs.openjdk.org/browse/JDK-8314476) needs maintainer approval

### Issue
 * [JDK-8314476](https://bugs.openjdk.org/browse/JDK-8314476): TestJstatdPortAndServer.java failed with "java.rmi.NoSuchObjectException: no such object in table" (**Bug** - P4 - Approved)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/179.diff">https://git.openjdk.org/jdk21u/pull/179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/179#issuecomment-1727584591)