### PR TITLE
8316400: Exclude jdk/jfr/event/runtime/TestResidentSetSizeEvent.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -747,6 +747,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 # jdk_jfr
 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
+jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8316400](https://bugs.openjdk.org/browse/JDK-8316400), commit [2e2d49c7](https://github.com/openjdk/jdk/commit/2e2d49c76d7bb43a431b5c4f2552beef8798258b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 18 Sep 2023 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316400](https://bugs.openjdk.org/browse/JDK-8316400) needs maintainer approval

### Issue
 * [JDK-8316400](https://bugs.openjdk.org/browse/JDK-8316400): Exclude jdk/jfr/event/runtime/TestResidentSetSizeEvent.java on AIX (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/180.diff">https://git.openjdk.org/jdk21u/pull/180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/180#issuecomment-1727634216)