### PR TITLE
8315578: PPC builds are broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -49,6 +49,7 @@ public enum Architecture {
     RISCV64(64, ByteOrder.LITTLE_ENDIAN),
     LOONGARCH64(64, ByteOrder.LITTLE_ENDIAN),
     S390(64, ByteOrder.BIG_ENDIAN),
+    PPC(32, ByteOrder.BIG_ENDIAN),
     PPC64(64, ByteOrder.BIG_ENDIAN),
     PPC64LE(64, ByteOrder.LITTLE_ENDIAN),
     MIPSEL(32, ByteOrder.LITTLE_ENDIAN),
@@ -153,6 +154,14 @@ public enum Architecture {
     @ForceInline
     public static boolean isS390() {
         return PlatformProps.TARGET_ARCH_IS_S390;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is PPC, big-endian}
+     */
+    @ForceInline
+    public static boolean isPPC() {
+        return PlatformProps.TARGET_ARCH_IS_PPC;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -59,6 +59,7 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
     static final boolean TARGET_ARCH_IS_LOONGARCH64 = "@@OPENJDK_TARGET_CPU@@" == "loongarch64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
+    static final boolean TARGET_ARCH_IS_PPC     = "@@OPENJDK_TARGET_CPU@@" == "ppc";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
     static final boolean TARGET_ARCH_IS_PPC64LE = "@@OPENJDK_TARGET_CPU@@" == "ppc64le";
     static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -30,6 +30,7 @@ import jdk.internal.misc.Unsafe;
 
 import static jdk.internal.util.Architecture.AARCH64;
 import static jdk.internal.util.Architecture.ARM;
+import static jdk.internal.util.Architecture.PPC;
 import static jdk.internal.util.Architecture.PPC64;
 import static jdk.internal.util.Architecture.PPC64LE;
 import static jdk.internal.util.Architecture.RISCV64;
@@ -81,6 +82,7 @@ public class ArchTest {
                 Arguments.of("loongarch64", LOONGARCH64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isLOONGARCH64()),
                 Arguments.of("mips64el", MIPS64EL, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isMIPS64EL()),
                 Arguments.of("mipsel", MIPSEL, 32, ByteOrder.LITTLE_ENDIAN, Architecture.isMIPSEL()),
+                Arguments.of("ppc", PPC, 32, ByteOrder.BIG_ENDIAN, Architecture.isPPC()),
                 Arguments.of("ppc64", PPC64, 64, ByteOrder.BIG_ENDIAN, Architecture.isPPC64()),
                 Arguments.of("ppc64le", PPC64LE, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isPPC64LE()),
                 Arguments.of("riscv64", RISCV64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isRISCV64()),


### PR DESCRIPTION
Clean backport to unbreak another build configuration.

Additional testing:
 - [x] macosx-aarch64-server-fastdebug, `jdk/internal/util/ArchTest.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8315578](https://bugs.openjdk.org/browse/JDK-8315578) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315578](https://bugs.openjdk.org/browse/JDK-8315578): PPC builds are broken after JDK-8304913 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/186.diff">https://git.openjdk.org/jdk21u/pull/186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/186#issuecomment-1729477803)