### PR TITLE
8316461: Fix: make test outputs TEST SUCCESS after unsuccessful exit

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -860,8 +860,9 @@ define SetupRunJtregTestBody
 
   $$(eval $$(call SetupRunJtregTestCustom, $1))
 
-  clean-workdir-$1:
+  clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
+	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
       $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
@@ -907,7 +908,7 @@ define SetupRunJtregTestBody
         done
   endif
 
-  run-test-$1: pre-run-test clean-workdir-$1
+  run-test-$1: pre-run-test clean-outputdirs-$1
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR) \
@@ -944,9 +945,9 @@ define SetupRunJtregTestBody
 	  $$(eval $1_TOTAL := 1) \
 	)
 
-  $1: run-test-$1 parse-test-$1 clean-workdir-$1
+  $1: run-test-$1 parse-test-$1 clean-outputdirs-$1
 
-  TARGETS += $1 run-test-$1 parse-test-$1 clean-workdir-$1
+  TARGETS += $1 run-test-$1 parse-test-$1 clean-outputdirs-$1
   TEST_TARGETS += parse-test-$1
 
 endef


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461): Fix: make test outputs TEST SUCCESS after unsuccessful exit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/187.diff">https://git.openjdk.org/jdk21u/pull/187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/187#issuecomment-1729481266)