### PR TITLE
8311823: Remove JFR: Uninitialized EventEmitter::_thread_id field

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp
@@ -44,7 +44,6 @@ class EventEmitter : public CHeapObj<mtTracing> {
   const JfrTicks& _end_time;
   Thread* _thread;
   JfrThreadLocal* _jfr_thread_local;
-  traceid _thread_id;
 
   EventEmitter(const JfrTicks& start_time, const JfrTicks& end_time);
   ~EventEmitter();


### PR DESCRIPTION
[JDK-8311823 ](https://bugs.openjdk.org/browse/JDK-8311823)

Remove Uninitialized EventEmitter::_thread_id field from src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp

GHA tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311823](https://bugs.openjdk.org/browse/JDK-8311823) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8311823](https://bugs.openjdk.org/browse/JDK-8311823)

### Issue
 * [JDK-8311823](https://bugs.openjdk.org/browse/JDK-8311823): JFR: Uninitialized EventEmitter::_thread_id field (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/191.diff">https://git.openjdk.org/jdk21u/pull/191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/191#issuecomment-1730507158)