### PR TITLE
8315770: serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -73,6 +73,9 @@ public class TestJmapCore {
     static void test(String type) throws Throwable {
         ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError",
+                // The test loads lots of small classes to exhaust Metaspace, skip method
+                // dependency verification to improve performance in debug builds.
+                Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "--show-version",
                 CoreUtils.getAlwaysPretouchArg(true),
                 TestJmapCore.class.getName(), type);
 


### PR DESCRIPTION
Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315770 merged as part of https://github.com/openjdk/jdk/pull/15631. https://github.com/openjdk/jdk/commit/877731d2a20249ce4724a071ba2da1faa56daca4.patch has been cleanly applied.

Below are the test results:
* after_release: **54.64s user 7.50s system 231% cpu 26.806 total**
* after_fastdebug: **247.97s user 12.78s system 407% cpu 1:03.99 total**
* before_release: **52.23s user 8.39s system 232% cpu 26.070 total**
* before_fastdebug: **504.20s user 9.34s system 211% cpu 4:03.01 total**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315770](https://bugs.openjdk.org/browse/JDK-8315770) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315770](https://bugs.openjdk.org/browse/JDK-8315770): serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/202/head:pull/202` \
`$ git checkout pull/202`

Update a local copy of the PR: \
`$ git checkout pull/202` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 202`

View PR using the GUI difftool: \
`$ git pr show -t 202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/202.diff">https://git.openjdk.org/jdk21u/pull/202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/202#issuecomment-1733510753)