### PR TITLE
8316859: RISC-V: Disable detection of V through HWCAP

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -149,12 +149,21 @@ void VM_Version::setup_cpu_available_features() {
 
 void VM_Version::os_aux_features() {
   uint64_t auxv = getauxval(AT_HWCAP);
-  int i = 0;
-  while (_feature_list[i] != nullptr) {
+  for (int i = 0; _feature_list[i] != nullptr; i++) {
+    if (_feature_list[i]->feature_bit() == HWCAP_ISA_V) {
+      // Special case for V: some dev boards only support RVV version 0.7, while
+      // the OpenJDK only supports RVV version 1.0. These two versions are not
+      // compatible with each other. Given the V bit is set through HWCAP on
+      // some custom kernels, regardless of the version, it can lead to
+      // generating V instructions on boards that don't support RVV version 1.0
+      // (ex: Sipeed LicheePi), leading to a SIGILL.
+      // That is an acceptable workaround as only Linux Kernel v6.5+ supports V,
+      // and that version already support hwprobe anyway
+      continue;
+    }
     if ((_feature_list[i]->feature_bit() & auxv) != 0) {
       _feature_list[i]->enable_feature();
     }
-    i++;
   }
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [311c7461](https://github.com/openjdk/jdk/commit/311c7461c8c0f5f1524d409736e4cceca8de9000) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ludovic Henry on 25 Sep 2023 and was reviewed by Robbin Ehn and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316859](https://bugs.openjdk.org/browse/JDK-8316859) needs maintainer approval

### Issue
 * [JDK-8316859](https://bugs.openjdk.org/browse/JDK-8316859): RISC-V: Disable detection of V through HWCAP (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/203.diff">https://git.openjdk.org/jdk21u/pull/203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/203#issuecomment-1733709937)