### PR TITLE
8311943: Cleanup usages of toLowerCase() and toUpperCase() in java.base

### DIFF
--- a/src/java.base/macosx/classes/apple/security/KeychainStore.java
+++ b/src/java.base/macosx/classes/apple/security/KeychainStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,7 +181,7 @@ public final class KeychainStore extends KeyStoreSpi {
             password = Long.toString(random.nextLong()).toCharArray();
         }
 
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
 
         if (!(entry instanceof KeyEntry keyEntry)) {
             return null;
@@ -271,7 +271,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public Certificate[] engineGetCertificateChain(String alias) {
         permissionCheck();
 
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
 
         if (entry instanceof KeyEntry keyEntry) {
             if (keyEntry.chain == null) {
@@ -302,7 +302,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public Certificate engineGetCertificate(String alias) {
         permissionCheck();
 
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
 
         if (entry != null) {
             if (entry instanceof TrustedCertEntry) {
@@ -337,7 +337,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public KeyStore.Entry engineGetEntry(String alias, KeyStore.ProtectionParameter protParam)
             throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableEntryException {
         if (engineIsCertificateEntry(alias)) {
-            Object entry = entries.get(alias.toLowerCase());
+            Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
             if (entry instanceof TrustedCertEntry tEntry) {
                 return new KeyStore.TrustedCertificateEntry(
                         tEntry.cert, Set.of(
@@ -359,7 +359,7 @@ public final class KeychainStore extends KeyStoreSpi {
     public Date engineGetCreationDate(String alias) {
         permissionCheck();
 
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
 
         if (entry != null) {
             if (entry instanceof TrustedCertEntry) {
@@ -427,7 +427,7 @@ public final class KeychainStore extends KeyStoreSpi {
                     entry.chainRefs = new long[entry.chain.length];
                 }
 
-                String lowerAlias = alias.toLowerCase();
+                String lowerAlias = alias.toLowerCase(Locale.ROOT);
                 if (entries.get(lowerAlias) != null) {
                     deletedEntries.put(lowerAlias, entries.get(lowerAlias));
                 }
@@ -491,7 +491,7 @@ public final class KeychainStore extends KeyStoreSpi {
                 entry.chainRefs = new long[entry.chain.length];
             }
 
-            String lowerAlias = alias.toLowerCase();
+            String lowerAlias = alias.toLowerCase(Locale.ROOT);
             if (entries.get(lowerAlias) != null) {
                 deletedEntries.put(lowerAlias, entries.get(alias));
             }
@@ -521,9 +521,10 @@ public final class KeychainStore extends KeyStoreSpi {
     {
         permissionCheck();
 
+        String lowerAlias = alias.toLowerCase(Locale.ROOT);
         synchronized(entries) {
-            Object entry = entries.remove(alias.toLowerCase());
-            deletedEntries.put(alias.toLowerCase(), entry);
+            Object entry = entries.remove(lowerAlias);
+            deletedEntries.put(lowerAlias, entry);
         }
     }
 
@@ -546,7 +547,7 @@ public final class KeychainStore extends KeyStoreSpi {
      */
     public boolean engineContainsAlias(String alias) {
         permissionCheck();
-        return entries.containsKey(alias.toLowerCase());
+        return entries.containsKey(alias.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -568,7 +569,7 @@ public final class KeychainStore extends KeyStoreSpi {
      */
     public boolean engineIsKeyEntry(String alias) {
         permissionCheck();
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
         return entry instanceof KeyEntry;
     }
 
@@ -581,7 +582,7 @@ public final class KeychainStore extends KeyStoreSpi {
      */
     public boolean engineIsCertificateEntry(String alias) {
         permissionCheck();
-        Object entry = entries.get(alias.toLowerCase());
+        Object entry = entries.get(alias.toLowerCase(Locale.ROOT));
         return entry instanceof TrustedCertEntry;
     }
 
@@ -806,10 +807,10 @@ public final class KeychainStore extends KeyStoreSpi {
             // Check whether a certificate with same alias already exists and is the same
             // If yes, we can return here - the existing entry must have the same
             // properties and trust settings
-            if (entries.contains(alias.toLowerCase())) {
+            if (entries.contains(alias.toLowerCase(Locale.ROOT))) {
                 int uniqueVal = 1;
                 String originalAlias = alias;
-                var co = entries.get(alias.toLowerCase());
+                var co = entries.get(alias.toLowerCase(Locale.ROOT));
                 while (co != null) {
                     if (co instanceof TrustedCertEntry tco) {
                         if (tco.cert.equals(tce.cert)) {
@@ -817,7 +818,7 @@ public final class KeychainStore extends KeyStoreSpi {
                         }
                     }
                     alias = originalAlias + " " + uniqueVal++;
-                    co = entries.get(alias.toLowerCase());
+                    co = entries.get(alias.toLowerCase(Locale.ROOT));
                 }
             }
 
@@ -900,7 +901,7 @@ public final class KeychainStore extends KeyStoreSpi {
             else
                 tce.date = new Date();
 
-            entries.put(alias.toLowerCase(), tce);
+            entries.put(alias.toLowerCase(Locale.ROOT), tce);
         } catch (Exception e) {
             // The certificate will be skipped.
             System.err.println("KeychainStore Ignored Exception: " + e);
@@ -971,12 +972,12 @@ public final class KeychainStore extends KeyStoreSpi {
         int uniqueVal = 1;
         String originalAlias = alias;
 
-        while (entries.containsKey(alias.toLowerCase())) {
+        while (entries.containsKey(alias.toLowerCase(Locale.ROOT))) {
             alias = originalAlias + " " + uniqueVal;
             uniqueVal++;
         }
 
-        entries.put(alias.toLowerCase(), ke);
+        entries.put(alias.toLowerCase(Locale.ROOT), ke);
     }
 
     private static class CertKeychainItemPair {

--- a/src/java.base/share/classes/java/net/ProxySelector.java
+++ b/src/java.base/share/classes/java/net/ProxySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package java.net;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
+
 import sun.security.util.SecurityConstants;
 
 /**
@@ -210,7 +212,7 @@ public abstract class ProxySelector {
 
         @Override
         public synchronized List<Proxy> select(URI uri) {
-            String scheme = uri.getScheme().toLowerCase();
+            String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
             if (scheme.equals("http") || scheme.equals("https")) {
                 return list;
             } else {

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -817,7 +817,7 @@ public class KeyStore {
         this.type = type;
 
         if (!skipDebug && pdebug != null) {
-            pdebug.println("KeyStore." + type.toUpperCase() + " type from: " +
+            pdebug.println("KeyStore." + type.toUpperCase(Locale.ROOT) + " type from: " +
                 getProviderName());
         }
     }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4725,7 +4725,7 @@ public final class DateTimeFormatterBuilder {
          * @return the position after the parse
          */
         private int parseOffsetBased(DateTimeParseContext context, CharSequence text, int prefixPos, int position, OffsetIdPrinterParser parser) {
-            String prefix = text.subSequence(prefixPos, position).toString().toUpperCase();
+            String prefix = text.subSequence(prefixPos, position).toString().toUpperCase(Locale.ROOT);
             if (position >= text.length()) {
                 context.setParsed(ZoneId.of(prefix));
                 return position;

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import jdk.internal.org.xml.sax.InputSource;
 import jdk.internal.org.xml.sax.SAXException;
@@ -1601,7 +1602,7 @@ public abstract class Parser {
                             //          PI target name may not be empty string [#2.6]
                             //          PI target name 'XML' is reserved [#2.6]
                             if ((str.isEmpty())
-                                    || (mXml.name.equals(str.toLowerCase()) == true)) {
+                                    || (mXml.name.equals(str.toLowerCase(Locale.ROOT)) == true)) {
                                 panic(FAULT);
                             }
                             //          This is processing instruction
@@ -2858,7 +2859,7 @@ public abstract class Parser {
             String expenc;
             if (is.getEncoding() != null) {
                 //              Ignore encoding in the xml text decl.
-                expenc = is.getEncoding().toUpperCase();
+                expenc = is.getEncoding().toUpperCase(Locale.ROOT);
                 if (expenc.equals("UTF-16")) {
                     reader = bom(is.getByteStream(), 'U');  // UTF-16 [#4.3.3]
                 } else {
@@ -3156,7 +3157,7 @@ public abstract class Parser {
                         case 'A':
                         case '_':
                             bkch();
-                            str = name(false).toLowerCase();
+                            str = name(false).toLowerCase(Locale.ROOT);
                             if ("version".equals(str) == true) {
                                 if (st != 1) {
                                     panic(FAULT);
@@ -3170,7 +3171,7 @@ public abstract class Parser {
                                 if (st != 2) {
                                     panic(FAULT);
                                 }
-                                mInp.xmlenc = eqstr('=').toUpperCase();
+                                mInp.xmlenc = eqstr('=').toUpperCase(Locale.ROOT);
                                 enc = mInp.xmlenc;
                                 st = 3;
                             } else if ("standalone".equals(str) == true) {
@@ -3178,7 +3179,7 @@ public abstract class Parser {
                                 {
                                     panic(FAULT);
                                 }
-                                str = eqstr('=').toLowerCase();
+                                str = eqstr('=').toLowerCase(Locale.ROOT);
                                 //              Check the 'standalone' value and use it [#5.1]
                                 if (str.equals("yes") == true) {
                                     mIsSAlone = true;

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -1279,7 +1279,7 @@ public final class LauncherHelper {
     }
 
     private static <T> Stream<String> toStringStream(Set<T> s) {
-        return s.stream().map(e -> e.toString().toLowerCase());
+        return s.stream().map(e -> e.toString().toLowerCase(Locale.ROOT));
     }
 
     private static boolean isJrt(ModuleReference mref) {

--- a/src/java.base/share/classes/sun/net/spi/DefaultProxySelector.java
+++ b/src/java.base/share/classes/sun/net/spi/DefaultProxySelector.java
@@ -377,7 +377,7 @@ public class DefaultProxySelector extends ProxySelector {
             if (disjunct.isEmpty())
                 continue;
             disjunctionEmpty = false;
-            String regex = disjunctToRegex(disjunct.toLowerCase());
+            String regex = disjunctToRegex(disjunct.toLowerCase(Locale.ROOT));
             joiner.add(regex);
         }
         return disjunctionEmpty ? null : Pattern.compile(joiner.toString());

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -34,6 +34,7 @@ import java.net.UnknownHostException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -149,7 +150,7 @@ public class NTLMAuthentication extends AuthenticationInfo {
             username = s;
             ntdomain = defaultDomain;
         } else {
-            ntdomain = s.substring (0, i).toUpperCase();
+            ntdomain = s.substring (0, i).toUpperCase(Locale.ROOT);
             username = s.substring (i+1);
         }
         password = pw.getPassword();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -289,7 +289,7 @@ abstract class UnixFileStore
         if (value != null) {
             String[] values = value.split("\\s");
             for (String s: values) {
-                s = s.trim().toLowerCase();
+                s = s.trim().toLowerCase(Locale.ROOT);
                 if (s.equals(feature)) {
                     return FeatureStatus.PRESENT;
                 }

--- a/src/java.base/windows/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/windows/classes/java/lang/ProcessImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,7 @@ final class ProcessImpl extends Process {
 
     // Old version that can be bypassed
     private boolean isShellFile(String executablePath) {
-        String upPath = executablePath.toUpperCase();
+        String upPath = executablePath.toUpperCase(Locale.ROOT);
         return (upPath.endsWith(".CMD") || upPath.endsWith(".BAT"));
     }
 

--- a/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -30,6 +30,7 @@ import java.net.InetAddress;
 import java.net.PasswordAuthentication;
 import java.net.UnknownHostException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import sun.net.NetProperties;
@@ -95,7 +96,7 @@ public class NTLMAuthentication extends AuthenticationInfo {
             public String run() {
                 String localhost;
                 try {
-                    localhost = InetAddress.getLocalHost().getHostName().toUpperCase();
+                    localhost = InetAddress.getLocalHost().getHostName().toUpperCase(Locale.ROOT);
                 } catch (UnknownHostException e) {
                      localhost = "localhost";
                 }
@@ -136,7 +137,7 @@ public class NTLMAuthentication extends AuthenticationInfo {
                 username = s;
                 ntdomain = defaultDomain;
             } else {
-                ntdomain = s.substring (0, i).toUpperCase();
+                ntdomain = s.substring (0, i).toUpperCase(Locale.ROOT);
                 username = s.substring (i+1);
             }
             password = new String (pw.getPassword());


### PR DESCRIPTION
Backport this patch to fix potential issues when default locale is `tr`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311943](https://bugs.openjdk.org/browse/JDK-8311943) needs maintainer approval

### Issue
 * [JDK-8311943](https://bugs.openjdk.org/browse/JDK-8311943): Cleanup usages of toLowerCase() and toUpperCase() in java.base (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/205.diff">https://git.openjdk.org/jdk21u/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/205#issuecomment-1734823951)