### PR TITLE
8316933: RISC-V: compiler/vectorapi/VectorCastShape128Test.java fails when using RVV

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1898,13 +1898,13 @@ void C2_MacroAssembler::integer_narrow_v(VectorRegister dst, BasicType dst_bt, i
       }
     }
   } else if (src_bt == T_INT) {
-      // T_SHORT
-      vsetvli(t0, t0, Assembler::e16, Assembler::mf2);
-      vncvt_x_x_w(dst, src);
-      if (dst_bt == T_BYTE) {
-        vsetvli(t0, t0, Assembler::e8, Assembler::mf2);
-        vncvt_x_x_w(dst, dst);
-      }
+    // T_SHORT
+    vsetvli(t0, t0, Assembler::e16, Assembler::mf2);
+    vncvt_x_x_w(dst, src);
+    if (dst_bt == T_BYTE) {
+      vsetvli(t0, t0, Assembler::e8, Assembler::mf2);
+      vncvt_x_x_w(dst, dst);
+    }
   } else if (src_bt == T_SHORT) {
     vsetvli(t0, t0, Assembler::e8, Assembler::mf2);
     vncvt_x_x_w(dst, src);
@@ -1920,8 +1920,6 @@ void C2_MacroAssembler::VFLOATCVT##_safe(VectorRegister dst, VectorRegister src)
 }
 
 VFCVT_SAFE(vfcvt_rtz_x_f_v);
-VFCVT_SAFE(vfwcvt_rtz_x_f_v);
-VFCVT_SAFE(vfncvt_rtz_x_f_w);
 
 #undef VFCVT_SAFE
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -242,8 +242,6 @@
                         VectorRegister src, BasicType src_bt);
 
   void vfcvt_rtz_x_f_v_safe(VectorRegister dst, VectorRegister src);
-  void vfwcvt_rtz_x_f_v_safe(VectorRegister dst, VectorRegister src);
-  void vfncvt_rtz_x_f_w_safe(VectorRegister dst, VectorRegister src);
 
   void extract_v(Register dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);
   void extract_fp_v(FloatRegister dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3199,13 +3199,12 @@ instruct vcvtStoX_fp_extend(vReg dst, vReg src) %{
   effect(TEMP_DEF dst);
   format %{ "vcvtStoX_fp_extend $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mf2);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ integer_extend_v(as_VectorRegister($dst$$reg), (bt == T_FLOAT ? T_INT : T_LONG),
+                        Matcher::vector_length(this), as_VectorRegister($src$$reg), T_SHORT);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
-    __ vfwcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-    if (Matcher::vector_element_basic_type(this) == T_DOUBLE) {
-      __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
-      __ vfwcvt_f_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
-    }
+    __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3311,12 +3310,11 @@ instruct vcvtFtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtFtoX_narrow $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mf2);
-    __ vfncvt_rtz_x_f_w_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-    if (Matcher::vector_element_basic_type(this) == T_BYTE) {
-      __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mf2);
-      __ vncvt_x_x_w(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
-    }
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ integer_narrow_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
+                        as_VectorRegister($dst$$reg), T_INT);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3339,8 +3337,11 @@ instruct vcvtFtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtFtoL $dst, $src" %}
   ins_encode %{
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
-    __ vfwcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
+    __ vfwcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3368,8 +3369,11 @@ instruct vcvtDtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtDtoX_narrow $dst, $src" %}
   ins_encode %{
+    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
+    __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
     __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2);
-    __ vfncvt_rtz_x_f_w_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
+    __ vfncvt_rtz_x_f_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
     BasicType bt = Matcher::vector_element_basic_type(this);
     if (bt == T_BYTE || bt == T_SHORT) {
       __ integer_narrow_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),


### PR DESCRIPTION
Hi, This issue also exists in the JDK21U, so i would like to backport this to jdk21u make vector api work correctly using latest qemu. see jbs issue for exception information.
```
zifeihan@plct-c8:~/qemu-master-riscv64/bin$ ./qemu-riscv64 -version
qemu-riscv64 version 8.1.50
Copyright (c) 2003-2023 Fabrice Bellard and the QEMU Project developers
```
By the way, using a lower version of qemu (qemu-riscv64 version 7.0.91) no such problems were encountered. we infer that version 8.1.50 of qemu adds better checks.
`test/hotspot/jtreg/compiler/vectorapi/VectorCastShape128Test.java` passed with fastdebug and using latest qemu.
### Testing:
qemu 8.1.50 with UseRVV:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316933](https://bugs.openjdk.org/browse/JDK-8316933) needs maintainer approval

### Issue
 * [JDK-8316933](https://bugs.openjdk.org/browse/JDK-8316933): RISC-V: compiler/vectorapi/VectorCastShape128Test.java fails when using RVV (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/206.diff">https://git.openjdk.org/jdk21u/pull/206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/206#issuecomment-1736865337)