### PR TITLE
8313779: RISC-V: use andn / orn in the MD5 instrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1655,6 +1655,28 @@ void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
   sign_extend(Rd, Rd, 32);
 }
 
+// Rd = Rs1 & (~Rd2)
+void MacroAssembler::andn(Register Rd, Register Rs1, Register Rs2) {
+  if (UseZbb) {
+    Assembler::andn(Rd, Rs1, Rs2);
+    return;
+  }
+
+  notr(Rd, Rs2);
+  andr(Rd, Rs1, Rd);
+}
+
+// Rd = Rs1 | (~Rd2)
+void MacroAssembler::orn(Register Rd, Register Rs1, Register Rs2) {
+  if (UseZbb) {
+    Assembler::orn(Rd, Rs1, Rs2);
+    return;
+  }
+
+  notr(Rd, Rs2);
+  orr(Rd, Rs1, Rd);
+}
+
 // Note: load_unsigned_short used to be called load_unsigned_word.
 int MacroAssembler::load_unsigned_short(Register dst, Address src) {
   int off = offset();

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -763,6 +763,10 @@ public:
   void orrw(Register Rd, Register Rs1, Register Rs2);
   void xorrw(Register Rd, Register Rs1, Register Rs2);
 
+  // logic with negate
+  void andn(Register Rd, Register Rs1, Register Rs2);
+  void orn(Register Rd, Register Rs1, Register Rs2);
+
   // revb
   void revb_h_h(Register Rd, Register Rs, Register tmp = t0);                           // reverse bytes in halfword in lower 16 bits, sign-extend
   void revb_w_w(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);      // reverse bytes in lower word, sign-extend

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3996,7 +3996,7 @@ class StubGenerator: public StubCodeGenerator {
     // rtmp1 = rtmp1 + x + ac
     reg_cache.get_u32(rtmp2, k, rmask32);
     __ addw(rtmp1, rtmp1, rtmp2);
-    __ li(rtmp2, t);
+    __ mv(rtmp2, t);
     __ addw(rtmp1, rtmp1, rtmp2);
 
     // a += rtmp1 + x + ac
@@ -4017,8 +4017,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andr(rtmp1, b, c);
 
     // rtmp2 = (~b) & d
-    __ notr(rtmp2, b);
-    __ andr(rtmp2, rtmp2, d);
+    __ andn(rtmp2, d, b);
 
     // rtmp1 = (b & c) | ((~b) & d)
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4036,9 +4035,8 @@ class StubGenerator: public StubCodeGenerator {
     // rtmp1 = b & d
     __ andr(rtmp1, b, d);
 
-    // rtmp2 = (c & (~d))
-    __ notr(rtmp2, d);
-    __ andr(rtmp2, rtmp2, c);
+    // rtmp2 = c & (~d)
+    __ andn(rtmp2, c, d);
 
     // rtmp1 = (b & d) | (c & (~d))
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4068,8 +4066,7 @@ class StubGenerator: public StubCodeGenerator {
               int k, int s, int t,
               Register rtmp1, Register rtmp2, Register rmask32) {
     // rtmp1 = c ^ (b | (~d))
-    __ notr(rtmp2, d);
-    __ orr(rtmp1, b, rtmp2);
+    __ orn(rtmp1, b, d);
     __ xorr(rtmp1, c, rtmp1);
 
     m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t,
@@ -4192,7 +4189,7 @@ class StubGenerator: public StubCodeGenerator {
       __ mv(ofs, ofs_arg);
       __ mv(limit, limit_arg);
     }
-    __ li(rmask32, MASK_32);
+    __ mv(rmask32, MASK_32);
 
     // to minimize the number of memory operations:
     // read the 4 state 4-byte values in pairs, with a single ld,


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [4726960f](https://github.com/openjdk/jdk/commit/4726960fcdc9489fb8f9c7e1a100828f1347c30c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

MD5 implementation already backported to jdk21u: [4eafc45](https://github.com/openjdk/jdk21u/commit/4eafc454c2df46e99106920713050065000efc24)

The commit being backported was authored by Antonios Printezis on 7 Aug 2023 and was reviewed by Ludovic Henry and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313779](https://bugs.openjdk.org/browse/JDK-8313779) needs maintainer approval

### Issue
 * [JDK-8313779](https://bugs.openjdk.org/browse/JDK-8313779): RISC-V: use andn / orn in the MD5 instrinsic (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/209.diff">https://git.openjdk.org/jdk21u/pull/209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/209#issuecomment-1738799745)