### PR TITLE
8315766: Parallelize gc/stress/TestStressIHOPMultiThread.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 package gc.stress;
 
  /*
- * @test TestStressIHOPMultiThread
+ * @test
  * @bug 8148397
  * @key stress
  * @summary Stress test for IHOP
@@ -34,21 +34,41 @@ package gc.stress;
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread1.log
  *              -Dtimeout=2 -DheapUsageMinBound=30 -DheapUsageMaxBound=80
  *              -Dthreads=2 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=2m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread2.log
  *              -Dtimeout=2 -DheapUsageMinBound=60 -DheapUsageMaxBound=90
  *              -Dthreads=3 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=4m -XX:-G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread3.log
  *              -Dtimeout=2 -DheapUsageMinBound=40 -DheapUsageMaxBound=90
  *              -Dthreads=5 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread4.log
  *              -Dtimeout=2 -DheapUsageMinBound=20 -DheapUsageMaxBound=90
  *              -Dthreads=10 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx512m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread5.log


### PR DESCRIPTION
Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315766 merged as part of https://github.com/openjdk/jdk/pull/15710. https://github.com/openjdk/jdk/commit/edd454b502b9bacde55492820e52655bbac63b89.patch could be cleanly applied.

Below are the test results:
* before_release: **1642.99s user 146.56s system 291% cpu 10:14.77 total**
* after_release: **1613.99s user 125.32s system 1323% cpu 2:11.44 total**
* before_fastdebug: **1214.26s user 54.36s system 200% cpu 10:34.09 total**
* after_fastdebug: **1246.25s user 57.25s system 889% cpu 2:26.55 total**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315766](https://bugs.openjdk.org/browse/JDK-8315766) needs maintainer approval

### Issue
 * [JDK-8315766](https://bugs.openjdk.org/browse/JDK-8315766): Parallelize gc/stress/TestStressIHOPMultiThread.java test (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/211.diff">https://git.openjdk.org/jdk21u/pull/211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/211#issuecomment-1739513453)