### PR TITLE
8316879: RegionMatches1Tests fails if CompactStrings are disabled after JDK-8302163

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2156,6 +2156,10 @@ public final class String
              (ooffset > (long)other.length() - len)) {
             return false;
         }
+        // Any strings match if len <= 0
+        if (len <= 0) {
+           return true;
+        }
         byte[] tv = value;
         byte[] ov = other.value;
         byte coder = coder();

--- a/test/jdk/java/lang/String/RegionMatches.java
+++ b/test/jdk/java/lang/String/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,34 @@
 
 /**
  * @test
- * @bug 4016509
- * @summary test regionMatches corner case
+ * @bug 4016509 8316879
+ * @summary test regionMatches corner cases
+ * @run junit RegionMatches
  */
 
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegionMatches {
 
-  public static void main (String args[]) throws Exception {
-      String s1="abc";
-      String s2="def";
+  private final String s1_LATIN1 = "abc";
+  private final String s2_LATIN1 = "def";
 
-      if (!s1.regionMatches(0,s2,0,Integer.MIN_VALUE))
-          throw new RuntimeException("Integer overflow in RegionMatches");
+  private final String s1_UTF16 = "\u041e\u0434\u043d\u0430\u0436\u0434\u044b";
+  private final String s2_UTF16 = "\u0432\u0441\u0442\u0443\u0434\u0435\u043d";
+
+  @Test
+  public void TestLATIN1() {
+      // Test for 4016509
+      boolean result = s1_LATIN1.regionMatches(0, s2_LATIN1, 0, Integer.MIN_VALUE);
+      assertTrue(result, "Integer overflow in RegionMatches when comparing LATIN1 strings");
+  }
+
+  @Test
+  public void TestUTF16() throws UnsupportedEncodingException{
+      // Test for 8316879
+      boolean result = s1_UTF16.regionMatches(0, s2_UTF16, 0, Integer.MIN_VALUE + 1);
+      assertTrue(result, "Integer overflow in RegionMatches when comparing UTF16 strings");
   }
 }


### PR DESCRIPTION
Clean backport of JDK-8316879.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316879](https://bugs.openjdk.org/browse/JDK-8316879) needs maintainer approval

### Issue
 * [JDK-8316879](https://bugs.openjdk.org/browse/JDK-8316879): RegionMatches1Tests fails if CompactStrings are disabled after JDK-8302163 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/216.diff">https://git.openjdk.org/jdk21u/pull/216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/216#issuecomment-1741185643)