### PR TITLE
Backport b38bcae1bad399d0a3ffc091835bf89140550bc2

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1009,7 +1009,7 @@ JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvm
 
 jvmtiError
 JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list) {
-  if (!JvmtiExport::can_support_virtual_threads()) {
+  if (get_capabilities()->can_support_virtual_threads == 0) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
   JavaThread* current = JavaThread::current();
@@ -1127,7 +1127,7 @@ JvmtiEnv::ResumeThreadList(jint request_count, const jthread* request_list, jvmt
 
 jvmtiError
 JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list) {
-  if (!JvmtiExport::can_support_virtual_threads()) {
+  if (get_capabilities()->can_support_virtual_threads == 0) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
   jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,12 @@ private:
   // all capabilities ever acquired
   static jvmtiCapabilities acquired_capabilities;
 
+  // counter for the agents possess can_support_virtual_threads capability
+  static int _can_support_virtual_threads_count;
+
+  // lock to access the class data
+  static Mutex* _capabilities_lock;
+
   // basic intenal operations
   static jvmtiCapabilities *either(const jvmtiCapabilities *a, const jvmtiCapabilities *b, jvmtiCapabilities *result);
   static jvmtiCapabilities *both(const jvmtiCapabilities *a, const jvmtiCapabilities *b, jvmtiCapabilities *result);
@@ -60,6 +66,14 @@ private:
   static jvmtiCapabilities init_onload_capabilities();
   static jvmtiCapabilities init_always_solo_capabilities();
   static jvmtiCapabilities init_onload_solo_capabilities();
+
+  // returns nullptr in onload phase
+  static Mutex* lock();
+
+  // get_potential_capabilities without lock
+  static void get_potential_capabilities_nolock(const jvmtiCapabilities* current,
+                                                const jvmtiCapabilities* prohibited,
+                                                jvmtiCapabilities* result);
 
 public:
   static void initialize();


### PR DESCRIPTION
Clean backport to improve Loom reliability.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk_loom hotspot_loom`
 - [x] macos-aarch64-server-fastdebug, `serviceability/jvmti`
 