### PR TITLE
8314551: More generic way to handshake GC threads with monitor deflation

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "gc/shared/suspendibleThreadSet.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -1641,8 +1641,8 @@ public:
   bool evaluate_at_safepoint() const override { return false; }
   VMOp_Type type() const override { return VMOp_RendezvousGCThreads; }
   void doit() override {
-    SuspendibleThreadSet::synchronize();
-    SuspendibleThreadSet::desynchronize();
+    Universe::heap()->safepoint_synchronize_begin();
+    Universe::heap()->safepoint_synchronize_end();
   };
 };
 


### PR DESCRIPTION
Clean backport to to complement [JDK-8307236](https://bugs.openjdk.org/browse/JDK-8307236) that is already in JDK 21. There is no bugtail in JDK 22 so far. Attn @rkennke.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot:tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314551](https://bugs.openjdk.org/browse/JDK-8314551) needs maintainer approval

### Issue
 * [JDK-8314551](https://bugs.openjdk.org/browse/JDK-8314551): More generic way to handshake GC threads with monitor deflation (**Bug** - P4 - Approved)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/222.diff">https://git.openjdk.org/jdk21u/pull/222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/222#issuecomment-1742944147)