### PR TITLE
8317257: RISC-V: llvm build broken

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1509,7 +1509,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   if (LockingMode == LM_MONITOR) {
     if (op->info() != nullptr) {
       add_debug_info_for_null_check_here(op->info());
-      __ null_check(obj);
+      __ null_check(obj, -1);
     }
     __ j(*op->stub()->entry());
   } else if (op->code() == lir_lock) {


### PR DESCRIPTION
Please review this backport to jdk21u.
It fixes issues with building risc-v port with clang/llvm

Almost clean, one part of original fix wasn't needed in 21u due to missing issue with statis_assert
The fix is pretty trivial, just make a hint to compile which method should be called here, identical to arm64 fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8317257](https://bugs.openjdk.org/browse/JDK-8317257) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317257](https://bugs.openjdk.org/browse/JDK-8317257): RISC-V: llvm build broken (**Bug** - P3 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/223.diff">https://git.openjdk.org/jdk21u/pull/223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/223#issuecomment-1743486914)