### PR TITLE
8313368: (fc) FileChannel.size returns 0 on block special files

### DIFF
--- a/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
@@ -45,6 +45,11 @@
 #define fstatvfs64 fstatvfs
 #endif
 
+#if defined(__linux__)
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+#endif
+
 #include "jni.h"
 #include "nio.h"
 #include "nio_util.h"
@@ -169,7 +174,7 @@ Java_sun_nio_ch_UnixFileDispatcherImpl_size0(JNIEnv *env, jobject this, jobject 
     if (fstat64(fd, &fbuf) < 0)
         return handle(env, -1, "Size failed");
 
-#ifdef BLKGETSIZE64
+#if defined(__linux__)
     if (S_ISBLK(fbuf.st_mode)) {
         uint64_t size;
         if (ioctl(fd, BLKGETSIZE64, &size) < 0)

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,10 @@
  */
 
 /* @test
- * @bug 8054029
+ * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary Block devices should not report size=0 on Linux
+ * @run main/manual BlockDeviceSize
  */
 
 import java.io.RandomAccessFile;
@@ -56,8 +57,8 @@ public class BlockDeviceSize {
             System.err.println("File " + BLK_FNAME + " not found." +
                     " Skipping test");
         } catch (AccessDeniedException ade) {
-            System.err.println("Access to " + BLK_FNAME + " is denied." +
-                    " Run test as root.");
+            throw new RuntimeException("Access to " + BLK_FNAME + " is denied."
+                    + " Run test as root.", ade);
         }
     }
 }


### PR DESCRIPTION
Backport of fix for JDK-8313368.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313368](https://bugs.openjdk.org/browse/JDK-8313368) needs maintainer approval

### Issue
 * [JDK-8313368](https://bugs.openjdk.org/browse/JDK-8313368): (fc) FileChannel.size returns 0 on block special files (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/228.diff">https://git.openjdk.org/jdk21u/pull/228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/228#issuecomment-1747394216)