### PR TITLE
8316337: (bf) Concurrency issue in DirectByteBuffer.Deallocator

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -75,31 +75,15 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[byte]
 
-    private static class Deallocator
-        implements Runnable
-    {
-
-        private long address;
-        private long size;
-        private int capacity;
-
-        private Deallocator(long address, long size, int capacity) {
-            assert (address != 0);
-            this.address = address;
-            this.size = size;
-            this.capacity = capacity;
+    private record Deallocator(long address, long size, int capacity) implements Runnable {
+        private Deallocator {
+            assert address != 0;
         }
 
         public void run() {
-            if (address == 0) {
-                // Paranoia
-                return;
-            }
             UNSAFE.freeMemory(address);
-            address = 0;
             Bits.unreserveMemory(size, capacity);
         }
-
     }
 
     private final Cleaner cleaner;

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -116,28 +116,33 @@ public abstract sealed class MappedByteBuffer
     }
 
     UnmapperProxy unmapper() {
-        return fd != null ?
-                new UnmapperProxy() {
-                    @Override
-                    public long address() {
-                        return address;
-                    }
+        return fd == null
+                ? null
+                : new UnmapperProxy() {
 
-                    @Override
-                    public FileDescriptor fileDescriptor() {
-                        return fd;
-                    }
+            // Ensure safe publication as MappedByteBuffer.this.address is not final
+            private final long addr = address;
 
-                    @Override
-                    public boolean isSync() {
-                        return isSync;
-                    }
+            @Override
+            public long address() {
+                return addr;
+            }
 
-                    @Override
-                    public void unmap() {
-                        Unsafe.getUnsafe().invokeCleaner(MappedByteBuffer.this);
-                    }
-                } : null;
+            @Override
+            public FileDescriptor fileDescriptor() {
+                return fd;
+            }
+
+            @Override
+            public boolean isSync() {
+                return isSync;
+            }
+
+            @Override
+            public void unmap() {
+                Unsafe.getUnsafe().invokeCleaner(MappedByteBuffer.this);
+            }
+        };
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1041,10 +1041,10 @@ public class FileChannelImpl
 
     // -- Memory-mapped buffers --
 
-    private abstract static class Unmapper
+    private sealed abstract static class Unmapper
         implements Runnable, UnmapperProxy
     {
-        private volatile long address;
+        private final long address;
         protected final long size;
         protected final long cap;
         private final FileDescriptor fd;
@@ -1081,10 +1081,7 @@ public class FileChannelImpl
         }
 
         public void unmap() {
-            if (address == 0)
-                return;
             nd.unmap(address, size);
-            address = 0;
 
             // if this mapping has a valid file descriptor then we close it
             if (fd.valid()) {
@@ -1101,7 +1098,7 @@ public class FileChannelImpl
         protected abstract void decrementStats();
     }
 
-    private static class DefaultUnmapper extends Unmapper {
+    private static final class DefaultUnmapper extends Unmapper {
 
         // keep track of non-sync mapped buffer usage
         static volatile int count;
@@ -1134,7 +1131,7 @@ public class FileChannelImpl
         }
     }
 
-    private static class SyncUnmapper extends Unmapper {
+    private static final class SyncUnmapper extends Unmapper {
 
         // keep track of mapped buffer usage
         static volatile int count;


### PR DESCRIPTION
Clean backport to improve safety. Records are available in JDK 21, so the whole thing works.

Additional testing:
  - [x] macos-aarch64-server-fastdebug, `java/nio`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316337](https://bugs.openjdk.org/browse/JDK-8316337) needs maintainer approval

### Issue
 * [JDK-8316337](https://bugs.openjdk.org/browse/JDK-8316337): (bf) Concurrency issue in DirectByteBuffer.Deallocator (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/231/head:pull/231` \
`$ git checkout pull/231`

Update a local copy of the PR: \
`$ git checkout pull/231` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 231`

View PR using the GUI difftool: \
`$ git pr show -t 231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/231.diff">https://git.openjdk.org/jdk21u/pull/231.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/231#issuecomment-1751275392)