### PR TITLE
8317736: Stream::handleReset locks twice

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -622,7 +622,7 @@ class Stream<T> extends ExchangeImpl<T> {
                 }
                 closed = true;
             } finally {
-                stateLock.lock();
+                stateLock.unlock();
             }
             try {
                 int error = frame.getErrorCode();


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [508fa717](https://urldefense.com/v3/__https://github.com/openjdk/jdk/commit/508fa71753171e125cd5345490cba1a1e545eb13__;!!ACWV5N9M2RV99hQ!L7JZX6ByIVOsnTQ4fToPsbuXw1nR4VScaRToZ1klgvC3cpCETSV1eDoGEXSskFpM5Ahe--ttf5AFHK2Pp7EbSDOyX1k$) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Daniel Fuchs on 9 Oct 2023 and was reviewed by Conor Cleary, Daniel Jeliński, Jaikiran Pai and Vyom Tewari.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317736](https://bugs.openjdk.org/browse/JDK-8317736) needs maintainer approval

### Issue
 * [JDK-8317736](https://bugs.openjdk.org/browse/JDK-8317736): Stream::handleReset locks twice (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/234.diff">https://git.openjdk.org/jdk21u/pull/234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/234#issuecomment-1753355185)