### PR TITLE
8317706: Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -451,6 +451,7 @@ java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
+java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706), commit [fcff222f](https://github.com/openjdk/jdk/commit/fcff222f9245df4c9ae42b55ef0ef202af969233) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 10 Oct 2023 and was reviewed by Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706) needs maintainer approval

### Issue
 * [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706): Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/237.diff">https://git.openjdk.org/jdk21u/pull/237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/237#issuecomment-1754589657)