### PR TITLE
8317711: Exclude gtest/GTestWrapper.java on AIX

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -138,6 +138,7 @@ serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 #############################################################################
 
+gtest/GTestWrapper.java 8306561 aix-ppc64
 gtest/NMTGtests.java#nmt-detail 8306561 aix-ppc64
 gtest/NMTGtests.java#nmt-summary 8306561 aix-ppc64
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8317711](https://bugs.openjdk.org/browse/JDK-8317711), commit [ef41aa02](https://github.com/openjdk/jdk/commit/ef41aa02b84961158f3cb333b6d98fbf48ff0ebc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 10 Oct 2023 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317711](https://bugs.openjdk.org/browse/JDK-8317711) needs maintainer approval

### Issue
 * [JDK-8317711](https://bugs.openjdk.org/browse/JDK-8317711): Exclude gtest/GTestWrapper.java on AIX (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/238.diff">https://git.openjdk.org/jdk21u/pull/238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/238#issuecomment-1754589884)