### PR TITLE
8317327: Remove JT_JAVA dead code in jib-profiles.js

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -945,10 +945,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: input.build_os,
             target_cpu: input.build_cpu,
             dependencies: [ "jtreg", "gnumake", "boot_jdk", "devkit", "jib" ],
-            labels: "test",
-            environment: {
-                "JT_JAVA": common.boot_jdk_home
-            }
+            labels: "test"
         }
     };
     profiles = concatObjects(profiles, testOnlyProfiles);


### PR DESCRIPTION
Backporting a clean cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317327](https://bugs.openjdk.org/browse/JDK-8317327) needs maintainer approval

### Issue
 * [JDK-8317327](https://bugs.openjdk.org/browse/JDK-8317327): Remove JT_JAVA dead code in jib-profiles.js (**Bug** - P5 - Approved) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/239.diff">https://git.openjdk.org/jdk21u/pull/239.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/239#issuecomment-1755208960)