### PR TITLE
8219652: [aix] Tests failing with JNI attach problems.

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,7 +91,7 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 # :hotspot_runtime
 
-
+runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,7 +92,6 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 # :hotspot_runtime
 
 
-runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64
@@ -155,9 +154,6 @@ vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 generic-all
-vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
-vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64
-vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-x64
 

--- a/test/hotspot/jtreg/runtime/jni/terminatedThread/libterminatedThread.c
+++ b/test/hotspot/jtreg/runtime/jni/terminatedThread/libterminatedThread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
 #include <string.h>
 
 #include "jni.h"
+
+#define STACK_SIZE 0x100000
 
 JavaVM* jvm;
 jobject nativeThread;
@@ -79,11 +81,14 @@ Java_TestTerminatedThread_createTerminatedThread
     fprintf(stderr, "Test ERROR. Can't extract JavaVM: %d\n", res);
     exit(1);
   }
-
-  if ((res = pthread_create(&thread, NULL, thread_start, NULL)) != 0) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, STACK_SIZE);
+  if ((res = pthread_create(&thread, &attr, thread_start, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_create failed: %s (%d)\n", strerror(res), res);
     exit(1);
   }
+  pthread_attr_destroy(&attr);
 
   if ((res = pthread_join(thread, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_join failed: %s (%d)\n", strerror(res), res);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,11 +128,16 @@ void* THREAD_start(void* t) {
         return NULL;
     }
 #else // !windows & !sun
-    int result = pthread_create(&(thread->id),NULL,procedure,thread);
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stack_size = 0x100000;
+    pthread_attr_setstacksize(&attr, stack_size);
+    int result = pthread_create(&(thread->id), &attr, procedure, thread);
     if (result != 0) {
         perror("failed to create a native thread");
         return NULL;
     }
+    pthread_attr_destroy(&attr);
 #endif // !windows & !sun
     };
     return thread;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8219652](https://bugs.openjdk.org/browse/JDK-8219652) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

I also add [JDK-8317136](https://bugs.openjdk.org/browse/JDK-8317136) and [JDK-8317790](https://bugs.openjdk.org/browse/JDK-8317790) inline which fix a test exclusion.

Other than the additions, the changes apply clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8317790](https://bugs.openjdk.org/browse/JDK-8317790) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8317136](https://bugs.openjdk.org/browse/JDK-8317136) needs maintainer approval
- [x] [JDK-8219652](https://bugs.openjdk.org/browse/JDK-8219652) needs maintainer approval

### Issues
 * [JDK-8219652](https://bugs.openjdk.org/browse/JDK-8219652): [aix] Tests failing with JNI attach problems. (**Bug** - P4 - Approved)
 * [JDK-8317136](https://bugs.openjdk.org/browse/JDK-8317136): [AIX] Problem List runtime/jni/terminatedThread/TestTerminatedThread.java (**Bug** - P4 - Approved)
 * [JDK-8317790](https://bugs.openjdk.org/browse/JDK-8317790): Fix Bug entry for exclusion of runtime/jni/terminatedThread/TestTerminatedThread.java on AIX (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/240.diff">https://git.openjdk.org/jdk21u/pull/240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/240#issuecomment-1756960310)