### PR TITLE
8317803: Exclude java/net/Socket/asyncClose/Race.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -547,6 +547,8 @@ java/net/MulticastSocket/Test.java                              7145658,8308807 
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
+java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
+
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8317803](https://bugs.openjdk.org/browse/JDK-8317803), commit [1161e3da](https://github.com/openjdk/jdk/commit/1161e3da14dde739aa6d76bba082662babb8d2d8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It is a test exclusion for AIX, applies clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317803](https://bugs.openjdk.org/browse/JDK-8317803) needs maintainer approval

### Issue
 * [JDK-8317803](https://bugs.openjdk.org/browse/JDK-8317803): Exclude java/net/Socket/asyncClose/Race.java on AIX (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/241.diff">https://git.openjdk.org/jdk21u/pull/241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/241#issuecomment-1756977411)