### PR TITLE
8317839: Exclude java/nio/channels/Channels/SocketChannelStreams.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -553,6 +553,8 @@ java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc6
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/Channels/SocketChannelStreams.java            8317838 aix-ppc64
+
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8317839](https://bugs.openjdk.org/browse/JDK-8317839), commit [ca96fd3b](https://github.com/openjdk/jdk/commit/ca96fd3b07958a7de6274bd945490bb9e79c2170) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

A test exclusion for AIX, applies clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317839](https://bugs.openjdk.org/browse/JDK-8317839) needs maintainer approval

### Issue
 * [JDK-8317839](https://bugs.openjdk.org/browse/JDK-8317839): Exclude java/nio/channels/Channels/SocketChannelStreams.java on AIX (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/242.diff">https://git.openjdk.org/jdk21u/pull/242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/242#issuecomment-1756993307)