### PR TITLE
8311261: [AIX] TestAlwaysPreTouchStacks.java fails due to java.lang.RuntimeException: Did not find expected NMT output

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CyclicBarrier;
 /*
  * @test
  * @summary Test AlwaysPreTouchThreadStacks
+ * @requires os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8311261](https://bugs.openjdk.org/browse/JDK-8311261), commit [d5c6b0d0](https://github.com/openjdk/jdk/commit/d5c6b0d0bbad696045eb46e268d28c86cb8c2a4e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Varada M on 24 Jul 2023 and was reviewed by Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311261](https://bugs.openjdk.org/browse/JDK-8311261) needs maintainer approval

### Issue
 * [JDK-8311261](https://bugs.openjdk.org/browse/JDK-8311261): [AIX] TestAlwaysPreTouchStacks.java fails due to java.lang.RuntimeException: Did not find expected NMT output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/243/head:pull/243` \
`$ git checkout pull/243`

Update a local copy of the PR: \
`$ git checkout pull/243` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 243`

View PR using the GUI difftool: \
`$ git pr show -t 243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/243.diff">https://git.openjdk.org/jdk21u/pull/243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/243#issuecomment-1757116915)