### PR TITLE
8315026: ProcessHandle implementation listing processes on AIX should use getprocs64

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,12 @@
  */
 
 #include "jni.h"
+#include "jni_util.h"
 
 #include "ProcessHandleImpl_unix.h"
 
 #include <sys/procfs.h>
+#include <procinfo.h>
 
 /*
  * Implementation of native ProcessHandleImpl functions for AIX.
@@ -36,9 +38,127 @@
 
 void os_initNative(JNIEnv *env, jclass clazz) {}
 
+/*
+ * Return pids of active processes, and optionally parent pids and
+ * start times for each process.
+ * For a specific non-zero pid, only the direct children are returned.
+ * If the pid is zero, all active processes are returned.
+ * Use getprocs64 to accumulate any process following the rules above.
+ * The resulting pids are stored into an array of longs named jarray.
+ * The number of pids is returned if they all fit.
+ * If the parentArray is non-null, store also the parent pid.
+ * In this case the parentArray must have the same length as the result pid array.
+ * Of course in the case of a given non-zero pid all entries in the parentArray
+ * will contain this pid, so this array does only make sense in the case of a given
+ * zero pid.
+ * If the jstimesArray is non-null, store also the start time of the pid.
+ * In this case the jstimesArray must have the same length as the result pid array.
+ * If the array(s) (is|are) too short, excess pids are not stored and
+ * the desired length is returned.
+ */
 jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
                     jlongArray jparentArray, jlongArray jstimesArray) {
-    return unix_getChildren(env, jpid, jarray, jparentArray, jstimesArray);
+    pid_t pid = (pid_t) jpid;
+    jlong* pids = NULL;
+    jlong* ppids = NULL;
+    jlong* stimes = NULL;
+    jsize parentArraySize = 0;
+    jsize arraySize = 0;
+    jsize stimesSize = 0;
+    jsize count = 0;
+
+    arraySize = (*env)->GetArrayLength(env, jarray);
+    JNU_CHECK_EXCEPTION_RETURN(env, -1);
+    if (jparentArray != NULL) {
+        parentArraySize = (*env)->GetArrayLength(env, jparentArray);
+        JNU_CHECK_EXCEPTION_RETURN(env, -1);
+
+        if (arraySize != parentArraySize) {
+            JNU_ThrowIllegalArgumentException(env, "array sizes not equal");
+            return 0;
+        }
+    }
+    if (jstimesArray != NULL) {
+        stimesSize = (*env)->GetArrayLength(env, jstimesArray);
+        JNU_CHECK_EXCEPTION_RETURN(env, -1);
+
+        if (arraySize != stimesSize) {
+            JNU_ThrowIllegalArgumentException(env, "array sizes not equal");
+            return 0;
+        }
+    }
+
+    const int chunk = 100;
+    struct procentry64 ProcessBuffer[chunk];
+    pid_t idxptr = 0;
+    int i, num = 0;
+
+    do { // Block to break out of on Exception
+        pids = (*env)->GetLongArrayElements(env, jarray, NULL);
+        if (pids == NULL) {
+            break;
+        }
+        if (jparentArray != NULL) {
+            ppids  = (*env)->GetLongArrayElements(env, jparentArray, NULL);
+            if (ppids == NULL) {
+                break;
+            }
+        }
+        if (jstimesArray != NULL) {
+            stimes  = (*env)->GetLongArrayElements(env, jstimesArray, NULL);
+            if (stimes == NULL) {
+                break;
+            }
+        }
+
+        while ((num = getprocs64(ProcessBuffer, sizeof(struct procentry64), NULL,
+                                 sizeof(struct fdsinfo64), &idxptr, chunk)) != -1) {
+            for (i = 0; i < num; i++) {
+                pid_t childpid = (pid_t) ProcessBuffer[i].pi_pid;
+                pid_t ppid = (pid_t) ProcessBuffer[i].pi_ppid;
+
+                // Get the parent pid, and start time
+                if (pid == 0 || ppid == pid) {
+                    if (count < arraySize) {
+                        // Only store if it fits
+                        pids[count] = (jlong) childpid;
+
+                        if (ppids != NULL) {
+                            // Store the parentPid
+                            ppids[count] = (jlong) ppid;
+                        }
+                        if (stimes != NULL) {
+                            // Store the process start time
+                            stimes[count] = ((jlong) ProcessBuffer[i].pi_start) * 1000;;
+                        }
+                    }
+                    count++; // Count to tabulate size needed
+                }
+            }
+            if (num < chunk) {
+                break;
+            }
+        }
+    } while (0);
+
+    if (pids != NULL) {
+        (*env)->ReleaseLongArrayElements(env, jarray, pids, 0);
+    }
+    if (ppids != NULL) {
+        (*env)->ReleaseLongArrayElements(env, jparentArray, ppids, 0);
+    }
+    if (stimes != NULL) {
+        (*env)->ReleaseLongArrayElements(env, jstimesArray, stimes, 0);
+    }
+
+    if (num == -1) {
+        JNU_ThrowByNameWithLastError(env,
+            "java/lang/RuntimeException", "Unable to retrieve Process info");
+        return -1;
+    }
+
+    // If more pids than array had size for; count will be greater than array size
+    return count;
 }
 
 pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -488,15 +488,25 @@ void unix_getUserInfo(JNIEnv* env, jobject jinfo, uid_t uid) {
  * The following functions are common on Solaris, Linux and AIX.
  */
 
-#if defined (__linux__) || defined(_AIX)
+#if defined (__linux__)
 
 /*
- * Returns the children of the requested pid and optionally each parent and
- * start time.
- * Reads /proc and accumulates any process who parent pid matches.
- * The resulting pids are stored into the array of longs.
+ * Return pids of active processes, and optionally parent pids and
+ * start times for each process.
+ * For a specific non-zero pid, only the direct children are returned.
+ * If the pid is zero, all active processes are returned.
+ * Reads /proc and accumulates any process following the rules above.
+ * The resulting pids are stored into an array of longs named jarray.
  * The number of pids is returned if they all fit.
- * If the array is too short, the negative of the desired length is returned.
+ * If the parentArray is non-null, store also the parent pid.
+ * In this case the parentArray must have the same length as the result pid array.
+ * Of course in the case of a given non-zero pid all entries in the parentArray
+ * will contain this pid, so this array does only make sense in the case of a given
+ * zero pid.
+ * If the jstimesArray is non-null, store also the start time of the pid.
+ * In this case the jstimesArray must have the same length as the result pid array.
+ * If the array(s) (is|are) too short, excess pids are not stored and
+ * the desired length is returned.
  */
 jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
                       jlongArray jparentArray, jlongArray jstimesArray) {
@@ -607,7 +617,7 @@ jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
     return count;
 }
 
-#endif // defined (__linux__) || defined(_AIX)
+#endif // defined (__linux__)
 
 /*
  * The following functions are for AIX.


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [4d904204](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fopenjdk%2Fjdk%2Fcommit%2F4d9042043ecade75d50c25574a445e6b8ef43618&data=05%7C01%7Cjoachim.kern%40sap.com%7C76faafca39b84ddcf13408dbcbc85c71%7C42f7676cf455423c82f6dc2d99791af7%7C0%7C0%7C638327833624807033%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=v5v6JFt12KN%2Bvs0nb26YpvanyOqgZr3LyE7FBTGio7Y%3D&reserved=0) from the [openjdk/jdk](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit.openjdk.org%2Fjdk&data=05%7C01%7Cjoachim.kern%40sap.com%7C76faafca39b84ddcf13408dbcbc85c71%7C42f7676cf455423c82f6dc2d99791af7%7C0%7C0%7C638327833624807033%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Gi20yCL7O4TFRsg%2Ble798pmWnMENvuYuTv4OsWA8gGY%3D&reserved=0) repository.
The commit being backported was authored by Joachim Kern on 13 Oct 2023 and was reviewed by Roger Riggs, Thomas Stuefe and Matthias Baesken.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315026](https://bugs.openjdk.org/browse/JDK-8315026) needs maintainer approval

### Issue
 * [JDK-8315026](https://bugs.openjdk.org/browse/JDK-8315026): ProcessHandle implementation listing processes on AIX should use getprocs64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/250.diff">https://git.openjdk.org/jdk21u/pull/250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/250#issuecomment-1761175985)