### PR TITLE
8317336: Assertion error thrown during 'this' escape analysis

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -678,7 +678,11 @@ class ThisEscapeAnalyzer extends TreeScanner {
 
     @Override
     public void visitForeachLoop(JCEnhancedForLoop tree) {
-        visitLooped(tree, super::visitForeachLoop);
+        visitLooped(tree, foreach -> {
+            scan(foreach.expr);
+            refs.discardExprs(depth);       // we don't handle iterator() yet
+            scan(foreach.body);
+        });
     }
 
     @Override
@@ -729,7 +733,10 @@ class ThisEscapeAnalyzer extends TreeScanner {
 
     @Override
     public void visitLambda(JCLambda lambda) {
-        visitDeferred(() -> visitScoped(false, () -> super.visitLambda(lambda)));
+        visitDeferred(() -> visitScoped(false, () -> {
+            scan(lambda.body);
+            refs.discardExprs(depth);       // needed in case body is a JCExpression
+        }));
     }
 
     @Override

--- a/test/langtools/tools/javac/warnings/ThisEscape.java
+++ b/test/langtools/tools/javac/warnings/ThisEscape.java
@@ -601,4 +601,20 @@ public class ThisEscape {
         public static final class Sub2 extends ThisEscapeSealed {
         }
     }
+
+    // Verify no assertion error occurs (JDK-8317336)
+    public static class ThisEscapeAssertionError {
+        public ThisEscapeAssertionError() {
+            System.out.println((Supplier<Object>)() -> this);
+        }
+    }
+
+    // Verify no assertion error occurs (JDK-8317336)
+    public static class ThisEscapeAssertionError2 {
+        public ThisEscapeAssertionError2() {
+            ThisEscapeAssertionError2[] array = new ThisEscapeAssertionError2[] { this };
+            for (Object obj : array)
+                ;
+        }
+    }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317336](https://bugs.openjdk.org/browse/JDK-8317336) needs maintainer approval

### Issue
 * [JDK-8317336](https://bugs.openjdk.org/browse/JDK-8317336): Assertion error thrown during 'this' escape analysis (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/252.diff">https://git.openjdk.org/jdk21u/pull/252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/252#issuecomment-1761639666)