### PR TITLE
8309663: test fails "assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe"

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2320,7 +2320,10 @@ bool StackRefCollector::do_frame(vframe* vf) {
       // Follow oops from compiled nmethod.
       if (jvf->cb() != nullptr && jvf->cb()->is_nmethod()) {
         _blk->set_context(_thread_tag, _tid, _depth, method);
-        jvf->cb()->as_nmethod()->oops_do(_blk);
+        // Need to apply load barriers for unmounted vthreads.
+        nmethod* nm = jvf->cb()->as_nmethod();
+        nm->run_nmethod_entry_barrier();
+        nm->oops_do(_blk);
         if (_blk->stopped()) {
           return false;
         }

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,4 +45,3 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
-serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#default 8309663 linux-x64


### PR DESCRIPTION
Clean backport to fix a corner case in JVMTI + concurrent GCs.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk_loom hotspot_loom`
 - [x] linux-x86_64-server-fastdebug, `tier1 tier2 tier3`
 - [x] linux-x86_64-server-fastdebug, `tier1 tier2 tier3` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309663](https://bugs.openjdk.org/browse/JDK-8309663) needs maintainer approval

### Issue
 * [JDK-8309663](https://bugs.openjdk.org/browse/JDK-8309663): test fails "assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/253.diff">https://git.openjdk.org/jdk21u/pull/253.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/253#issuecomment-1764846381)