### PR TITLE
8310512: Cleanup indentation in jfc files

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -735,8 +735,8 @@
     </event>
 
     <event name="jdk.Deserialization">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.InitialSecurityProperty">
@@ -745,13 +745,13 @@
     </event>
 
     <event name="jdk.SecurityPropertyModification">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.SecurityProviderService">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.TLSHandshake">
@@ -760,13 +760,13 @@
     </event>
 
     <event name="jdk.X509Validation">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.X509Certificate">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.JavaExceptionThrow">
@@ -921,15 +921,13 @@
 
 
 
-
-
   <!--
   Contents of the control element is not read by the JVM, it's used
   by JDK Mission Control and the 'jfr' tool to change settings that
   carry the control attribute.
   -->
     <control>
-     <selection name="gc" default="normal" label="Garbage Collector">
+      <selection name="gc" default="normal" label="Garbage Collector">
         <option label="Off" name="off">off</option>
         <option label="Normal" name="normal">normal</option>
         <option label="Detailed" name="detailed">detailed</option>
@@ -974,7 +972,7 @@
       </selection>
 
       <condition name="object-allocation-enabled" true="true" false="false">
-	 <not>
+        <not>
           <test name="allocation-profiling" operator="equal" value="off"/>
         </not>
       </condition>
@@ -1122,7 +1120,6 @@
       <text name="socket-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">20 ms</text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
-
     </control>
 
 </configuration>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -735,8 +735,8 @@
     </event>
 
     <event name="jdk.Deserialization">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.InitialSecurityProperty">
@@ -745,13 +745,13 @@
     </event>
 
     <event name="jdk.SecurityPropertyModification">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.SecurityProviderService">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.TLSHandshake">
@@ -760,13 +760,13 @@
     </event>
 
     <event name="jdk.X509Validation">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.X509Certificate">
-       <setting name="enabled">false</setting>
-       <setting name="stackTrace">true</setting>
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.JavaExceptionThrow">
@@ -927,7 +927,7 @@
   carry the control attribute.
   -->
     <control>
-        <selection name="gc" default="detailed" label="Garbage Collector">
+      <selection name="gc" default="detailed" label="Garbage Collector">
         <option label="Off" name="off">off</option>
         <option label="Normal" name="normal">normal</option>
         <option label="Detailed" name="detailed">detailed</option>
@@ -945,11 +945,11 @@
       </condition>
 
       <condition name="gc-enabled-detailed" true="true" false="false">
-       <or>
+        <or>
           <test name="gc" operator="equal" value="detailed"/>
           <test name="gc" operator="equal" value="high"/>
           <test name="gc" operator="equal" value="all"/>
-       </or>
+        </or>
       </condition>
 
       <condition name="gc-enabled-high" true="true" false="false">
@@ -967,7 +967,7 @@
         <option label="Off" name="off">0/s</option>
         <option label="Low" name="low">150/s</option>
         <option label="Medium" name="medium">300/s</option>
-	    <option label="High" name="high">1000/s</option>
+        <option label="High" name="high">1000/s</option>
         <option label="Maximum" name="maximum">1000000000/s</option>
       </selection>
 
@@ -1120,7 +1120,6 @@
       <text name="socket-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">10 ms</text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
-
     </control>
 
 </configuration>


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8310512](https://bugs.openjdk.org/browse/JDK-8310512), commit [3be50da6](https://github.com/openjdk/jdk/commit/3be50da636b986b267d15c4caa0147c100b96111) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 21 Jun 2023 and was reviewed by Erik Gahlin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310512](https://bugs.openjdk.org/browse/JDK-8310512) needs maintainer approval

### Issue
 * [JDK-8310512](https://bugs.openjdk.org/browse/JDK-8310512): Cleanup indentation in jfc files (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/260.diff">https://git.openjdk.org/jdk21u/pull/260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/260#issuecomment-1765697551)