### PR TITLE
8315706: com/sun/tools/attach/warnings/DynamicLoadWarningTest.java real fix for failure on AIX

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -3009,3 +3009,32 @@ void os::print_memory_mappings(char* addr, size_t bytes, outputStream* st) {}
 void os::jfr_report_memory_info() {}
 
 #endif // INCLUDE_JFR
+
+// Simulate the library search algorithm of dlopen() (in os::dll_load)
+int os::Aix::stat64x_via_LIBPATH(const char* path, struct stat64x* stat) {
+  if (path[0] == '/' ||
+      (path[0] == '.' && (path[1] == '/' ||
+                          (path[1] == '.' && path[2] == '/')))) {
+    return stat64x(path, stat);
+  }
+
+  const char* env = getenv("LIBPATH");
+  if (env == nullptr || *env == 0)
+    return -1;
+
+  int ret = -1;
+  size_t libpathlen = strlen(env);
+  char* libpath = NEW_C_HEAP_ARRAY(char, libpathlen + 1, mtServiceability);
+  char* combined = NEW_C_HEAP_ARRAY(char, libpathlen + strlen(path) + 1, mtServiceability);
+  char *saveptr, *token;
+  strcpy(libpath, env);
+  for (token = strtok_r(libpath, ":", &saveptr); token != nullptr; token = strtok_r(nullptr, ":", &saveptr)) {
+    sprintf(combined, "%s/%s", token, path);
+    if (0 == (ret = stat64x(combined, stat)))
+      break;
+  }
+
+  FREE_C_HEAP_ARRAY(char*, combined);
+  FREE_C_HEAP_ARRAY(char*, libpath);
+  return ret;
+}

--- a/src/hotspot/os/aix/os_aix.hpp
+++ b/src/hotspot/os/aix/os_aix.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2013, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,9 @@ class os::Aix {
 
   static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc);
   static void* resolve_function_descriptor(void* p);
+
+  // Simulate the library search algorithm of dlopen() (in os::dll_load)
+  static int stat64x_via_LIBPATH(const char* path, struct stat64x* stat);
 };
 
 #endif // OS_AIX_OS_AIX_HPP

--- a/src/hotspot/share/prims/jvmtiAgent.hpp
+++ b/src/hotspot/share/prims/jvmtiAgent.hpp
@@ -43,6 +43,10 @@ class JvmtiAgent : public CHeapObj<mtServiceability> {
   const char* _options;
   void* _os_lib;
   const char* _os_lib_path;
+#ifdef AIX
+  ino64_t _inode;
+  dev64_t _device;
+#endif
   const void* _jplis;
   bool _loaded;
   bool _absolute_path;
@@ -80,6 +84,12 @@ class JvmtiAgent : public CHeapObj<mtServiceability> {
   void initialization_end();
   const Ticks& initialization_time() const;
   const Tickspan& initialization_duration() const;
+#ifdef AIX
+  void set_inode(ino64_t inode);
+  void set_device(dev64_t device);
+  unsigned long inode() const;
+  unsigned long device() const;
+#endif
 
   bool load(outputStream* st = nullptr);
   void unload();

--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -243,6 +243,19 @@ bool JvmtiAgentList::is_dynamic_lib_loaded(void* os_lib) {
   }
   return false;
 }
+#ifdef AIX
+bool JvmtiAgentList::is_dynamic_lib_loaded(dev64_t device, ino64_t inode) {
+  JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
+  while (it.has_next()) {
+    JvmtiAgent* const agent = it.next();
+    if (!agent->is_static_lib() && device != 0 && inode != 0 &&
+        agent->device() == device && agent->inode() == inode) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif
 
 static bool match(JvmtiEnv* env, const JvmtiAgent* agent, const void* os_module_address) {
   assert(env != nullptr, "invariant");

--- a/src/hotspot/share/prims/jvmtiAgentList.hpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.hpp
@@ -78,6 +78,9 @@ class JvmtiAgentList : AllStatic {
 
   static bool is_static_lib_loaded(const char* name);
   static bool is_dynamic_lib_loaded(void* os_lib);
+#ifdef AIX
+  static bool is_dynamic_lib_loaded(dev64_t device, ino64_t inode);
+#endif
 
   static JvmtiAgent* lookup(JvmtiEnv* env, void* f_ptr);
 

--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -124,18 +124,15 @@ class DynamicLoadWarningTest {
                 .whenRunning(loadJvmtiAgent1)
                 .stderrShouldNotContain(JVMTI_AGENT_WARNING);
 
-        // test behavior on platforms that can detect if an agent library was previously loaded
-        if (!Platform.isAix()) {
-            // start loadJvmtiAgent1 via the command line, then dynamically load loadJvmtiAgent1
-            test().withOpts("-agentpath:" + jvmtiAgentPath1)
-                    .whenRunning(loadJvmtiAgent1)
-                    .stderrShouldNotContain(JVMTI_AGENT_WARNING);
+        // start loadJvmtiAgent1 via the command line, then dynamically load loadJvmtiAgent1
+        test().withOpts("-agentpath:" + jvmtiAgentPath1)
+                .whenRunning(loadJvmtiAgent1)
+                .stderrShouldNotContain(JVMTI_AGENT_WARNING);
 
-            // dynamically load loadJvmtiAgent1 twice, should be one warning
-            test().whenRunning(loadJvmtiAgent1)
-                    .whenRunning(loadJvmtiAgent1)
-                    .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
-        }
+        // dynamically load loadJvmtiAgent1 twice, should be one warning
+        test().whenRunning(loadJvmtiAgent1)
+                .whenRunning(loadJvmtiAgent1)
+                .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
     }
 
     /**


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8315706](https://bugs.openjdk.org/browse/JDK-8315706), commit [21c2dac1](https://github.com/openjdk/jdk/commit/21c2dac15957e6d71e8f32a55f3825671da097a9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Joachim Kern on 18 Sep 2023 and was reviewed by David Holmes and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315706](https://bugs.openjdk.org/browse/JDK-8315706) needs maintainer approval

### Issue
 * [JDK-8315706](https://bugs.openjdk.org/browse/JDK-8315706): com/sun/tools/attach/warnings/DynamicLoadWarningTest.java real fix for failure on AIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/261.diff">https://git.openjdk.org/jdk21u/pull/261.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/261#issuecomment-1765697310)