### PR TITLE
Backport 20ff603108a52468dd41020cbf6c0bf669e23861

### DIFF
--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -77,3 +77,15 @@ void LockStack::verify(const char* msg) const {
   }
 }
 #endif
+
+void LockStack::print_on(outputStream* st) {
+  for (int i = to_index(_top); (--i) >= 0;) {
+    st->print("LockStack[%d]: ", i);
+    oop o = _base[i];
+    if (oopDesc::is_oop(o)) {
+      o->print_on(st);
+    } else {
+      st->print_cr("not an oop: " PTR_FORMAT, p2i(o));
+    }
+  }
+}

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -30,8 +30,9 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/sizes.hpp"
 
-class Thread;
+class JavaThread;
 class OopClosure;
+class outputStream;
 
 class LockStack {
   friend class VMStructs;
@@ -91,6 +92,8 @@ public:
   // GC support
   inline void oops_do(OopClosure* cl);
 
+  // Printing
+  void print_on(outputStream* st);
 };
 
 #endif // SHARE_RUNTIME_LOCKSTACK_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1094,6 +1094,11 @@ void VMError::report(outputStream* st, bool _verbose) {
     print_stack_location(st, _context, continuation);
     st->cr();
 
+  STEP_IF("printing lock stack", _verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT);
+    st->print_cr("Lock stack of current Java thread (top to bottom):");
+    JavaThread::cast(_thread)->lock_stack().print_on(st);
+    st->cr();
+
   STEP_IF("printing code blobs if possible", _verbose)
     const int printed_capacity = max_error_log_print_code;
     address printed[printed_capacity];


### PR DESCRIPTION
Clean backport to improve crash diagnostics. This matters mostly for `LockingMode=2` case, which is not default in JDK 21. 

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `runtime/ErrorHandling` with different `LockingMode`-s