### PR TITLE
8315869: UseHeavyMonitors not used

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1912,15 +1912,6 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-  if (UseHeavyMonitors) {
-    if (FLAG_IS_CMDLINE(LockingMode) && LockingMode != LM_MONITOR) {
-      jio_fprintf(defaultStream::error_stream(),
-                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags", LockingMode);
-      return false;
-    }
-    FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
-  }
-
 #if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64) && !defined(S390)
   if (LockingMode == LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1050,13 +1050,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
-  develop(bool, UseHeavyMonitors, false,                                    \
-          "(Deprecated) Use heavyweight instead of lightweight Java "       \
-          "monitors")                                                       \
-                                                                            \
   develop(bool, VerifyHeavyMonitors, false,                                 \
           "Checks that no stack locking happens when using "                \
-          "+UseHeavyMonitors")                                              \
+          "-XX:LockingMode=0 (LM_MONITOR)")                                 \
                                                                             \
   product(bool, PrintStringTableStatistics, false,                          \
           "print statistics about the StringTable and SymbolTable")         \

--- a/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
+++ b/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
@@ -34,7 +34,7 @@
  * @test
  * @requires vm.continuations & vm.debug
  * @modules java.base/java.lang:+open
- * @run junit/othervm -XX:+UseHeavyMonitors CarrierThreadWaits
+ * @run junit/othervm -XX:LockingMode=0 CarrierThreadWaits
  */
 
 import java.lang.management.LockInfo;

--- a/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
+++ b/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
@@ -34,7 +34,7 @@
  * @test
  * @requires vm.continuations & vm.debug
  * @modules java.base/java.lang:+open
- * @run junit/othervm -XX:LockingMode=0 CarrierThreadWaits
+ * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:LockingMode=0 CarrierThreadWaits
  */
 
 import java.lang.management.LockInfo;

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
@@ -51,7 +51,7 @@
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64" | os.arch == "s390x"
  * @requires vm.debug
  * @library /test/lib
- * @run main/othervm/timeout=1600 -XX:+UseHeavyMonitors -XX:+VerifyHeavyMonitors MapLoops
+ * @run main/othervm/timeout=1600 -XX:LockingMode=0 -XX:+VerifyHeavyMonitors MapLoops
  */
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
@@ -51,7 +51,7 @@
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64" | os.arch == "s390x"
  * @requires vm.debug
  * @library /test/lib
- * @run main/othervm/timeout=1600 -XX:LockingMode=0 -XX:+VerifyHeavyMonitors MapLoops
+ * @run main/othervm/timeout=1600 -XX:+UnlockExperimentalVMOptions -XX:LockingMode=0 -XX:+VerifyHeavyMonitors MapLoops
  */
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;


### PR DESCRIPTION
Unclean backport to clean up JDK 21 and make future backports more clean. The removed option is `develop`, so there is no compatibility problems.

The uncleanliness comes from the need to `-XX:+UnlockExperimentalVMOptions` the flag.

Additional testing:
 - [x] `grep -R UseHeavyMonitors src/`, no hits
 - [x] `grep -R UseHeavyMonitors test/`, no hits
 - [x] macos-aarch64-server-fastdebug, affected tests pass
 - [x] macos-aarch64-server-release, affected tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315869](https://bugs.openjdk.org/browse/JDK-8315869) needs maintainer approval

### Issue
 * [JDK-8315869](https://bugs.openjdk.org/browse/JDK-8315869): UseHeavyMonitors not used (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/265.diff">https://git.openjdk.org/jdk21u/pull/265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/265#issuecomment-1766148133)