### PR TITLE
8317818: Combinatorial explosion during 'this' escape analysis

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -167,7 +167,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
 
     /** Used to terminate recursion in {@link #invokeInvokable invokeInvokable()}.
      */
-    private final Set<Pair<JCTree, RefSet<Ref>>> invocations = new HashSet<>();
+    private final Set<Pair<JCMethodDecl, RefSet<Ref>>> invocations = new HashSet<>();
 
     /** Snapshot of {@link #callStack} where a possible 'this' escape occurs.
      *  If non-null, a 'this' escape warning has been found in the current
@@ -590,7 +590,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
                 return;
 
             // Stop infinite recursion here
-            Pair<JCTree, RefSet<Ref>> invocation = Pair.of(site, refs.clone());
+            Pair<JCMethodDecl, RefSet<Ref>> invocation = Pair.of(methodInfo.declaration, refs.clone());
             if (!invocations.add(invocation))
                 return;
 

--- a/test/langtools/tools/javac/warnings/ThisEscape.java
+++ b/test/langtools/tools/javac/warnings/ThisEscape.java
@@ -617,4 +617,34 @@ public class ThisEscape {
                 ;
         }
     }
+
+    // Verify no infinite recursion loop occurs (JDK-8317818)
+    public static class ThisEscapeRecursionExplosion {
+        private Object obj;
+        public ThisEscapeRecursionExplosion() {
+            getObject();
+        }
+        private Object getObject() {
+            if (this.obj == null) {
+                this.obj = new Object();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+                getObject().hashCode();
+            }
+            return this.obj;
+        }
+    }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317818](https://bugs.openjdk.org/browse/JDK-8317818) needs maintainer approval

### Issue
 * [JDK-8317818](https://bugs.openjdk.org/browse/JDK-8317818): Combinatorial explosion during 'this' escape analysis (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/266.diff">https://git.openjdk.org/jdk21u/pull/266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/266#issuecomment-1766499487)