### PR TITLE
8312592: New parentheses warnings after HarfBuzz 7.2.0 update

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -470,7 +470,7 @@ else
    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers strict-aliasing \
-       unused-result array-bounds
+       unused-result array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference


### PR DESCRIPTION
Clean backport to unbreak JDK build on older platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312592](https://bugs.openjdk.org/browse/JDK-8312592) needs maintainer approval

### Issue
 * [JDK-8312592](https://bugs.openjdk.org/browse/JDK-8312592): New parentheses warnings after HarfBuzz 7.2.0 update (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/267.diff">https://git.openjdk.org/jdk21u/pull/267.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/267#issuecomment-1767971439)