### PR TITLE
8316894: make test  TEST="jtreg:test/jdk/..."  fails on AIX

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -178,7 +178,8 @@ ifeq ($(TEST_JOBS), 0)
       c = c * $(TEST_JOBS_FACTOR_JDL); \
       c = c * $(TEST_JOBS_FACTOR_MACHINE); \
       if (c < 1) c = 1; \
-      printf "%.0f", c; \
+      c = c + 0.5; \
+      printf "%d", c; \
     }')
 endif
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316894](https://bugs.openjdk.org/browse/JDK-8316894) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316894](https://bugs.openjdk.org/browse/JDK-8316894): make test  TEST="jtreg:test/jdk/..."  fails on AIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/269/head:pull/269` \
`$ git checkout pull/269`

Update a local copy of the PR: \
`$ git checkout pull/269` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 269`

View PR using the GUI difftool: \
`$ git pr show -t 269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/269.diff">https://git.openjdk.org/jdk21u/pull/269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/269#issuecomment-1768415161)