### PR TITLE
8316060: test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java may fail if heap is huge

### DIFF
--- a/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8297977
  * @summary Test that throwing OOM from reflected method gets InvocationTargetException
- * @run main/othervm/timeout=150 ReflectOutOfMemoryError
+ * @run main/othervm -Xmx128m ReflectOutOfMemoryError
  */
 import java.lang.reflect.*;
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bd52bbfa](https://github.com/openjdk/jdk/commit/bd52bbfa272691caab227d736021362c06449535) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 13 Sep 2023 and was reviewed by Leonid Mesnik and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316060](https://bugs.openjdk.org/browse/JDK-8316060) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316060](https://bugs.openjdk.org/browse/JDK-8316060): test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java may fail if heap is huge (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/270.diff">https://git.openjdk.org/jdk21u/pull/270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/270#issuecomment-1771455386)