### PR TITLE
8038244: (fs) Check return value of malloc in Java_sun_nio_fs_AixNativeDispatcher_getmntctl()

### DIFF
--- a/src/java.base/aix/native/libnio/fs/AixNativeDispatcher.c
+++ b/src/java.base/aix/native/libnio/fs/AixNativeDispatcher.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,10 @@ Java_sun_nio_fs_AixNativeDispatcher_getmntctl(JNIEnv* env, jclass this)
         }
         buffer_size *= 8;
         buffer = malloc(buffer_size);
+        if (buffer == NULL) {
+            throwUnixException(env, errno);
+            return NULL;
+        }
         must_free_buf = 1;
     }
     /* Treat zero entries like errors. */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8038244](https://bugs.openjdk.org/browse/JDK-8038244) needs maintainer approval

### Issue
 * [JDK-8038244](https://bugs.openjdk.org/browse/JDK-8038244): (fs) Check return value of malloc in Java_sun_nio_fs_AixNativeDispatcher_getmntctl() (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/271.diff">https://git.openjdk.org/jdk21u/pull/271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/271#issuecomment-1770924322)