### PR TITLE
8318089: Class space not marked as such with NMT when CDS is off

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -567,12 +567,6 @@ void Metaspace::initialize_class_space(ReservedSpace rs) {
          "wrong alignment");
 
   MetaspaceContext::initialize_class_space_context(rs);
-
-  // This does currently not work because rs may be the result of a split
-  // operation and NMT seems not to be able to handle splits.
-  // Will be fixed with JDK-8243535.
-  // MemTracker::record_virtual_memory_type((address)rs.base(), mtClass);
-
 }
 
 // Returns true if class space has been setup (initialize_class_space).
@@ -836,6 +830,9 @@ void Metaspace::global_initialize() {
           err_msg("Could not allocate compressed class space: " SIZE_FORMAT " bytes",
                    CompressedClassSpaceSize));
     }
+
+    // Mark class space as such
+    MemTracker::record_virtual_memory_type((address)rs.base(), mtClass);
 
     // Initialize space
     Metaspace::initialize_class_space(rs);


### PR DESCRIPTION
Hi all,

this fixes a display problem in NMT, where the class space size is incorrectly shown as "unknown" memory. Its very low-risk.

This pull request contains a backport of commit [c0e154c8](https://github.com/openjdk/jdk/commit/c0e154c876e586660b36af6441cd178bc8ebab89) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

 Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318089](https://bugs.openjdk.org/browse/JDK-8318089) needs maintainer approval

### Issue
 * [JDK-8318089](https://bugs.openjdk.org/browse/JDK-8318089): Class space not marked as such with NMT when CDS is off (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/273/head:pull/273` \
`$ git checkout pull/273`

Update a local copy of the PR: \
`$ git checkout pull/273` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 273`

View PR using the GUI difftool: \
`$ git pr show -t 273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/273.diff">https://git.openjdk.org/jdk21u/pull/273.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/273#issuecomment-1774506079)