### PR TITLE
8315088: C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3707,7 +3707,7 @@ void IdealLoopTree::enqueue_data_nodes(PhaseIdealLoop* phase, Unique_Node_List& 
 void IdealLoopTree::collect_loop_core_nodes(PhaseIdealLoop* phase, Unique_Node_List& wq) const {
   uint before = wq.size();
   wq.push(_head->in(LoopNode::LoopBackControl));
-  for (uint i = 0; i < wq.size(); ++i) {
+  for (uint i = before; i < wq.size(); ++i) {
     Node* n = wq.at(i);
     for (uint j = 0; j < n->req(); ++j) {
       Node* in = n->in(j);

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8315088
+ * @requires vm.compiler2.enabled
+ * @summary C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestBrokenEmptyLoopLogic::* -XX:-TieredCompilation TestBrokenEmptyLoopLogic
+ *
+ */
+
+public class TestBrokenEmptyLoopLogic {
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int i8 = 209, i = 1, i12 = 1;
+        while (++i < 8) {
+            for (int j = 5; j > 1; j -= 2) {
+                i12 = 1;
+                do {
+                } while (++i12 < 3);
+            }
+            for (int j = i; j < 5; ++j) {
+                i8 += i12;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to fix JDK 21 regression. The change was in mainline for 1.5 months, and there is no recorded bugtail.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, new regression test fails without the patch, passes with it
 - [x] linux-aarch64-server-fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315088](https://bugs.openjdk.org/browse/JDK-8315088) needs maintainer approval

### Issue
 * [JDK-8315088](https://bugs.openjdk.org/browse/JDK-8315088): C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/275/head:pull/275` \
`$ git checkout pull/275`

Update a local copy of the PR: \
`$ git checkout pull/275` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 275`

View PR using the GUI difftool: \
`$ git pr show -t 275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/275.diff">https://git.openjdk.org/jdk21u/pull/275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/275#issuecomment-1772322088)