### PR TITLE
8316741: BasicStroke.createStrokedShape miter-limits failing on small shapes

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/marlin/Renderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/Renderer.java
@@ -557,6 +557,7 @@ final class Renderer implements DPathConsumer2D, MarlinConst {
                   final int pix_boundsWidth, final int pix_boundsHeight,
                   final int windingRule)
     {
+        this.rdrCtx.doRender = true;
         this.windingRule = windingRule;
 
         // bounds as half-open intervals: minX <= x < maxX and minY <= y < maxY

--- a/src/java.desktop/share/classes/sun/java2d/marlin/RendererContext.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/RendererContext.java
@@ -78,6 +78,8 @@ final class RendererContext extends ReentrantContext implements MarlinConst {
     final MarlinCache cache;
     // flag indicating the shape is stroked (1) or filled (0)
     int stroking = 0;
+    // flag indicating to render the shape
+    boolean doRender = false;
     // flag indicating to clip the shape
     boolean doClip = false;
     // flag indicating if the path is closed or not (in advance) to handle properly caps
@@ -169,6 +171,7 @@ final class RendererContext extends ReentrantContext implements MarlinConst {
             stats.totalOffHeap = 0L;
         }
         stroking   = 0;
+        doRender   = false;
         doClip     = false;
         closedPath = false;
         clipInvScale = 0.0d;

--- a/src/java.desktop/share/classes/sun/java2d/marlin/Stroker.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/Stroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,25 +170,34 @@ final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
             miterScaledLimit = miterLimit * lineWidth2;
             this.miterLimitSq = miterScaledLimit * miterScaledLimit;
 
-            final double limitMin = ((this.rdrCtx.clipInvScale == 0.0d) ? JOIN_ERROR
-                    : (JOIN_ERROR * this.rdrCtx.clipInvScale))
-                    + lineWidth2;
+            if (rdrCtx.doRender) {
+                final double limitMin = ((this.rdrCtx.clipInvScale == 0.0d) ? JOIN_ERROR
+                        : (JOIN_ERROR * this.rdrCtx.clipInvScale))
+                        + lineWidth2;
 
-            this.joinLimitMinSq = limitMin * limitMin;
-
+                this.joinLimitMinSq = limitMin * limitMin;
+            } else {
+                // createStrokedShape(): disable limit checks:
+                this.joinLimitMinSq = 0.0;
+            }
         } else if (joinStyle == JOIN_ROUND) {
-            // chord:  s = 2 r * sin( phi / 2)
-            // height: h = 2 r * sin( phi / 4)^2
-            // small angles (phi < 90):
-            // h = s^2 / (8 r)
-            // so s^2 = (8 h * r)
+            if (rdrCtx.doRender) {
+                // chord:  s = 2 r * sin( phi / 2)
+                // height: h = 2 r * sin( phi / 4)^2
+                // small angles (phi < 90):
+                // h = s^2 / (8 r)
+                // so s^2 = (8 h * r)
 
-            // height max (note ROUND_JOIN_ERROR = 8 * JOIN_ERROR)
-            final double limitMin = ((this.rdrCtx.clipInvScale == 0.0d) ? ROUND_JOIN_ERROR
-                    : (ROUND_JOIN_ERROR * this.rdrCtx.clipInvScale));
+                // height max (note ROUND_JOIN_ERROR = 8 * JOIN_ERROR)
+                final double limitMin = ((this.rdrCtx.clipInvScale == 0.0d) ? ROUND_JOIN_ERROR
+                        : (ROUND_JOIN_ERROR * this.rdrCtx.clipInvScale));
 
-            // chord limit (s^2):
-            this.joinLimitMinSq = limitMin * this.lineWidth2;
+                // chord limit (s^2):
+                this.joinLimitMinSq = limitMin * this.lineWidth2;
+            } else {
+                // createStrokedShape(): disable limit checks:
+                this.joinLimitMinSq = 0.0;
+            }
         }
         this.prev = CLOSE;
 

--- a/src/java.desktop/share/classes/sun/java2d/marlin/Version.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/Version.java
@@ -27,7 +27,7 @@ package sun.java2d.marlin;
 
 public final class Version {
 
-    private static final String VERSION = "marlin-0.9.4.6-Unsafe-OpenJDK";
+    private static final String VERSION = "marlin-0.9.4.6.1-Unsafe-OpenJDK";
 
     public static String getVersion() {
         return VERSION;

--- a/test/jdk/sun/java2d/marlin/TestCreateStrokedShapeJoins.java
+++ b/test/jdk/sun/java2d/marlin/TestCreateStrokedShapeJoins.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.*;
+import java.awt.*;
+import java.awt.image.*;
+import java.awt.geom.*;
+import java.util.Arrays;
+import javax.imageio.*;
+
+/**
+ * @test
+ * @bug 8316741
+ * @summary Verifies that Marlin renderer's Stroker generates properly joins
+ * in createStrokedShape()
+ * @run main TestCreateStrokedShapeJoins
+ */
+public class TestCreateStrokedShapeJoins {
+
+    static final boolean SAVE_IMAGE = false;
+
+    private final static int W = 200;
+
+    private final static int[] REF_COUNTS = new int[] {4561, 4790, 5499};
+
+    public static void main(String[] args) throws Exception {
+        final int[] test = new int[] {
+                test(BasicStroke.JOIN_BEVEL),
+                test(BasicStroke.JOIN_ROUND),
+                test(BasicStroke.JOIN_MITER)
+        };
+
+        System.out.println("test: " + Arrays.toString(test));
+        System.out.println("ref:  " + Arrays.toString(REF_COUNTS));
+
+        // check results:
+        for (int i = 0; i < REF_COUNTS.length; i++) {
+            if (test[i] != REF_COUNTS[i]) {
+                throw new RuntimeException("Invalid test[" + i + "]: " + test[i] + " != " + REF_COUNTS[i]);
+            }
+        }
+    }
+
+    private static int test(int join) throws Exception {
+        final BufferedImage image = new BufferedImage(W, W, BufferedImage.TYPE_INT_ARGB);
+        final Graphics2D g = image.createGraphics();
+        try {
+            g.setPaint(Color.BLACK);
+            g.fillRect(0, 0, W, W);
+            g.setPaint(Color.WHITE);
+            g.setTransform(new AffineTransform(W, 0, 0, W, 0, 0));
+
+            final BasicStroke stroke = new BasicStroke(0.15f, 0, join, 10);
+
+            final Path2D p = new Path2D.Float();
+            p.moveTo(0.95f, 0.6f);
+            p.lineTo(0.5f, 0.5f);
+            p.lineTo(0.95f, 0.4f);
+
+            final Shape outline = stroke.createStrokedShape(p);
+            g.fill(outline);
+        } finally {
+            g.dispose();
+        }
+        if (SAVE_IMAGE) {
+            final File file = new File("TestCreateStrokedShapeJoins-" + join + ".png");
+            System.out.println("Writing " + file.getAbsolutePath());
+            ImageIO.write(image, "png", file);
+        }
+        int count = 0;
+
+        for (int y = 0; y < W; y++) {
+            for (int x = 0; x < W; x++) {
+                final int rgb = image.getRGB(x, y);
+                final int b = rgb & 0xFF;
+
+                if (b != 0) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
Backport from jdk22:
https://github.com/openjdk/jdk/commit/a876beb63d5d509b80366139ae4c6abe502efe1e

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316741](https://bugs.openjdk.org/browse/JDK-8316741) needs maintainer approval

### Issue
 * [JDK-8316741](https://bugs.openjdk.org/browse/JDK-8316741): BasicStroke.createStrokedShape miter-limits failing on small shapes (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/279.diff">https://git.openjdk.org/jdk21u/pull/279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/279#issuecomment-1773734751)