### PR TITLE
8318540: make test cannot run .jasm tests directly

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -357,7 +357,7 @@ ExpandJtregPath = \
 # with test id: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
 #      without: dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
 TestID = \
-    $(subst .sh,,$(subst .html,,$(subst .java,,$(suffix $(notdir $1)))))
+    $(subst .jasm,,$(subst .sh,,$(subst .html,,$(subst .java,,$(suffix $(notdir $1))))))
 
 # The test id starting with a hash (#testid) will be stripped by all
 # evals in ParseJtregTestSelectionInner and will be reinserted by calling


### PR DESCRIPTION
Clean backport to improve testing capabilities.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318540](https://bugs.openjdk.org/browse/JDK-8318540) needs maintainer approval

### Issue
 * [JDK-8318540](https://bugs.openjdk.org/browse/JDK-8318540): make test cannot run .jasm tests directly (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/281.diff">https://git.openjdk.org/jdk21u/pull/281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/281#issuecomment-1774790615)