### PR TITLE
8314330: java/foreign tests should respect vm flags when start new processes

### DIFF
--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -21,13 +21,12 @@
  * questions.
  */
 
-import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -57,22 +56,15 @@ public class UpcallTestHelper extends NativeTestHelper {
         assert !target.isArray();
 
         List<String> command = new ArrayList<>(List.of(
-            Paths.get(Utils.TEST_JDK)
-                    .resolve("bin")
-                    .resolve("java")
-                    .toAbsolutePath()
-                    .toString(),
             "--enable-preview",
             "--enable-native-access=ALL-UNNAMED",
             "-Djava.library.path=" + System.getProperty("java.library.path"),
             "-Djdk.internal.foreign.UpcallLinker.USE_SPEC=" + useSpec,
-            "-cp", Utils.TEST_CLASS_PATH,
             target.getName()
         ));
         command.addAll(Arrays.asList(programArgs));
-        Process process = new ProcessBuilder()
-            .command(command)
-            .start();
+
+        Process process = ProcessTools.createTestJvm(command).start();
 
         int result = process.waitFor();
         assertNotEquals(result, 0);


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `java/foreign` passe

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314330](https://bugs.openjdk.org/browse/JDK-8314330) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314330](https://bugs.openjdk.org/browse/JDK-8314330): java/foreign tests should respect vm flags when start new processes (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/285/head:pull/285` \
`$ git checkout pull/285`

Update a local copy of the PR: \
`$ git checkout pull/285` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 285`

View PR using the GUI difftool: \
`$ git pr show -t 285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/285.diff">https://git.openjdk.org/jdk21u/pull/285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/285#issuecomment-1775660041)