### PR TITLE
8317603: Improve exception messages thrown by sun.nio.ch.Net native methods (win)

### DIFF
--- a/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ Java_sun_nio_ch_DatagramChannelImpl_disconnect0(JNIEnv *env, jclass clazz,
 
     rv = connect((SOCKET)fd, &sa.sa, sa_len);
     if (rv == SOCKET_ERROR) {
-        handleSocketError(env, WSAGetLastError());
+        NET_ThrowNew(env, WSAGetLastError(), "connect");
     } else {
         /* Disable WSAECONNRESET errors as socket is no longer connected */
         BOOL enable = FALSE;
@@ -136,7 +136,10 @@ Java_sun_nio_ch_DatagramChannelImpl_receive0(JNIEnv *env, jclass clazz,
                 }
             } else if (theErr == WSAEWOULDBLOCK) {
                 return IOS_UNAVAILABLE;
-            } else return handleSocketError(env, theErr);
+            } else {
+                NET_ThrowNew(env, theErr, "recvfrom");
+                return IOS_THROWN;
+            }
         }
     } while (retry);
 
@@ -160,7 +163,8 @@ Java_sun_nio_ch_DatagramChannelImpl_send0(JNIEnv *env, jclass clazz,
         if (theErr == WSAEWOULDBLOCK) {
             return IOS_UNAVAILABLE;
         }
-        return handleSocketError(env, (jint)WSAGetLastError());
+        NET_ThrowNew(env, (jint)WSAGetLastError(), "sendto");
+        return IOS_THROWN;
     }
     return rv;
 }

--- a/src/java.base/windows/native/libnio/ch/IOUtil.c
+++ b/src/java.base/windows/native/libnio/ch/IOUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,8 +149,7 @@ Java_sun_nio_ch_IOUtil_configureBlocking(JNIEnv *env, jclass clazz,
     }
     result = ioctlsocket(fd, FIONBIO, &argp);
     if (result == SOCKET_ERROR) {
-        int error = WSAGetLastError();
-        handleSocketError(env, (jint)error);
+        NET_ThrowNew(env, WSAGetLastError(), "ioctlsocket");
     }
 }
 

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,8 @@ Java_sun_nio_ch_UnixDomainSockets_socket0(JNIEnv *env, jclass cl)
 {
     SOCKET s = WSASocketW(PF_UNIX, SOCK_STREAM, 0, &provider, 0, WSA_FLAG_OVERLAPPED);
     if (s == INVALID_SOCKET) {
-        return handleSocketError(env, WSAGetLastError());
+        NET_ThrowNew(env, WSAGetLastError(), "WSASocketW");
+        return IOS_THROWN;
     }
     SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
     return (int)s;

--- a/src/java.base/windows/native/libnio/ch/nio_util.h
+++ b/src/java.base/windows/native/libnio/ch/nio_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ jlong handleval(JNIEnv *env, jobject fdo);
 jint convertReturnVal(JNIEnv *env, jint n, jboolean r);
 jlong convertLongReturnVal(JNIEnv *env, jlong n, jboolean r);
 jboolean purgeOutstandingICMP(JNIEnv *env, jclass clazz, jint fd);
-jint handleSocketError(JNIEnv *env, int errorValue);
 
 #ifdef _WIN64
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317603](https://bugs.openjdk.org/browse/JDK-8317603) needs maintainer approval

### Issue
 * [JDK-8317603](https://bugs.openjdk.org/browse/JDK-8317603): Improve exception messages thrown by sun.nio.ch.Net native methods (win) (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/289/head:pull/289` \
`$ git checkout pull/289`

Update a local copy of the PR: \
`$ git checkout pull/289` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 289`

View PR using the GUI difftool: \
`$ git pr show -t 289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/289.diff">https://git.openjdk.org/jdk21u/pull/289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/289#issuecomment-1777129047)