### PR TITLE
8316411: compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with force inline by CompileCommand missing

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -52,6 +52,7 @@ public class TestConflictInlineCommands {
         analyzer.shouldNotContain("force inline by CompileCommand");
 
         pb = ProcessTools.createJavaProcessBuilder(
+                "-Xbatch",
                 "-XX:CompileCommand=dontinline,*TestConflictInlineCommands::*caller",
                 "-XX:CompileCommand=inline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*Launcher::main",
@@ -77,6 +78,9 @@ public class TestConflictInlineCommands {
                     sum += caller(i, 0);
                 }
             }
+            System.out.println("sum is:" + sum);
+            System.out.flush();
+            System.err.flush();
         }
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316411](https://bugs.openjdk.org/browse/JDK-8316411) needs maintainer approval

### Issue
 * [JDK-8316411](https://bugs.openjdk.org/browse/JDK-8316411): compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with force inline by CompileCommand missing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/290/head:pull/290` \
`$ git checkout pull/290`

Update a local copy of the PR: \
`$ git checkout pull/290` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 290`

View PR using the GUI difftool: \
`$ git pr show -t 290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/290.diff">https://git.openjdk.org/jdk21u/pull/290.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/290#issuecomment-1777501995)