### PR TITLE
8316414: C2: large byte array clone triggers "failed: malformed control flow" assertion failure on linux-x86

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4749,7 +4749,7 @@ const TypeInt* TypeAryPtr::narrow_size_type(const TypeInt* size) const {
   jint hi = size->_hi;
   jint lo = size->_lo;
   jint min_lo = 0;
-  jint max_hi = max_array_length(elem()->basic_type());
+  jint max_hi = max_array_length(elem()->array_element_basic_type());
   //if (index_not_size)  --max_hi;     // type of a valid array index, FTR
   bool chg = false;
   if (lo < min_lo) {

--- a/test/hotspot/jtreg/compiler/allocation/TestNewMaxLengthArray.java
+++ b/test/hotspot/jtreg/compiler/allocation/TestNewMaxLengthArray.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316414
+ * @summary C2: large byte array clone triggers "failed: malformed control flow" assertion failure on linux-x86
+ * @run main/othervm  -Xcomp -XX:CompileOnly=TestNewMaxLengthArray::createAndClone TestNewMaxLengthArray
+ */
+
+public class TestNewMaxLengthArray {
+
+    // Maximum length of a byte array on a 32-bits platform using default object
+    // alignment (8 bytes).
+    static final int MAX_BYTE_ARRAY_LENGTH = 0x7ffffffc;
+
+    public static byte[] createAndClone() {
+        byte[] array = new byte[MAX_BYTE_ARRAY_LENGTH];
+        return array.clone();
+    }
+
+    public static void main(String[] a) {
+        try {
+            createAndClone();
+        } catch (OutOfMemoryError oome) {
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to fix the C2 corner case.

Additional testing:
 - [x] New regression test passes _even with the patch_
 - [x] Linux x86_64 fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316414](https://bugs.openjdk.org/browse/JDK-8316414) needs maintainer approval

### Issue
 * [JDK-8316414](https://bugs.openjdk.org/browse/JDK-8316414): C2: large byte array clone triggers "failed: malformed control flow" assertion failure on linux-x86 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/292.diff">https://git.openjdk.org/jdk21u/pull/292.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/292#issuecomment-1779595781)