### PR TITLE
8312126: NullPointerException in CertStore.getCRLs after 8297955

### DIFF
--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
@@ -779,9 +779,13 @@ final class LDAPCertStoreImpl {
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
-            } else {
+            } else if (nameObject instanceof String) {
                 issuerName = (String)nameObject;
+            } else {
+                throw new CertStoreException(
+                    "unrecognized issuerName: must be String or byte[]");
             }
+
             // If all we want is CA certs, try to get the (probably shorter) ARL
             Collection<X509CRL> entryCRLs = Collections.emptySet();
             if (certChecking == null || certChecking.getBasicConstraints() != -1) {


### PR DESCRIPTION
Clean backport to fix the bug introduced by a change made a few months ago.

Additional testing:
 - [x] Linux AArch64 fastdebug, `jdk_security`
 - [x] Linux AArch64 fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126) needs maintainer approval

### Issue
 * [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126): NullPointerException in CertStore.getCRLs after 8297955 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/293/head:pull/293` \
`$ git checkout pull/293`

Update a local copy of the PR: \
`$ git checkout pull/293` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 293`

View PR using the GUI difftool: \
`$ git pr show -t 293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/293.diff">https://git.openjdk.org/jdk21u/pull/293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/293#issuecomment-1779611398)