### PR TITLE
8315971: ProblemList containers/docker/TestMemoryAwareness.java on linux-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -108,7 +108,7 @@ runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
-containers/docker/TestMemoryAwareness.java 8303470 linux-x64
+containers/docker/TestMemoryAwareness.java 8303470 linux-all
 
 #############################################################################
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [eb37c7e3](https://github.com/openjdk/jdk/commit/eb37c7e361527d937cf5d461a6cca54bd894e542) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 13 Sep 2023 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8315971](https://bugs.openjdk.org/browse/JDK-8315971) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315971](https://bugs.openjdk.org/browse/JDK-8315971): ProblemList containers/docker/TestMemoryAwareness.java on linux-all (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/294/head:pull/294` \
`$ git checkout pull/294`

Update a local copy of the PR: \
`$ git checkout pull/294` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 294`

View PR using the GUI difftool: \
`$ git pr show -t 294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/294.diff">https://git.openjdk.org/jdk21u/pull/294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/294#issuecomment-1780288926)