### PR TITLE
8318705: [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -579,6 +579,7 @@ java/rmi/transport/rapidExportUnexport/RapidExportUnexport.java 7146541 linux-al
 java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java       7191877 generic-all
 
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
+java/rmi/registry/multipleRegistries/MultipleRegistries.java    8268182 macosx-all
 
 java/rmi/Naming/DefaultRegistryPort.java                        8005619 windows-all
 java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java      8005619 windows-all


### PR DESCRIPTION
I would like to backport this as we see the error also in 21. Further, it is already listed for 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318705](https://bugs.openjdk.org/browse/JDK-8318705) needs maintainer approval

### Issue
 * [JDK-8318705](https://bugs.openjdk.org/browse/JDK-8318705): [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/295/head:pull/295` \
`$ git checkout pull/295`

Update a local copy of the PR: \
`$ git checkout pull/295` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 295`

View PR using the GUI difftool: \
`$ git pr show -t 295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/295.diff">https://git.openjdk.org/jdk21u/pull/295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/295#issuecomment-1780626797)