### PR TITLE
8316648: jrt-fs.jar classes not reproducible between standard and bootcycle builds

### DIFF
--- a/make/JrtfsJar.gmk
+++ b/make/JrtfsJar.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,10 @@ JIMAGE_PKGS := \
     jdk/internal/jrtfs \
     #
 
+# Compile jrt-fs.jar with the interim compiler, as it
+# ends up in the image, this will ensure reproducible classes
 $(eval $(call SetupJavaCompilation, BUILD_JRTFS, \
-    COMPILER := bootjdk, \
+    COMPILER := interim, \
     DISABLED_WARNINGS := options, \
     TARGET_RELEASE := $(TARGET_RELEASE_JDK8), \
     SRC := $(TOPDIR)/src/java.base/share/classes, \


### PR DESCRIPTION
Backport of https://bugs.openjdk.org/browse/JDK-8316648 to enable reproducible jrt-fs class compilation using the interim compiler.
Minimal risk based on using the build jdk interim compiler rather than the user provided bootjdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316648](https://bugs.openjdk.org/browse/JDK-8316648) needs maintainer approval

### Issue
 * [JDK-8316648](https://bugs.openjdk.org/browse/JDK-8316648): jrt-fs.jar classes not reproducible between standard and bootcycle builds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/300/head:pull/300` \
`$ git checkout pull/300`

Update a local copy of the PR: \
`$ git checkout pull/300` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 300`

View PR using the GUI difftool: \
`$ git pr show -t 300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/300.diff">https://git.openjdk.org/jdk21u/pull/300.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/300#issuecomment-1782858248)