### PR TITLE
8314242: Update applications/scimark/Scimark.java to accept VM flags

### DIFF
--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @library /test/lib
- * @requires vm.flagless
  * @run driver Scimark
  */
 
@@ -47,7 +46,9 @@ public class Scimark {
                             + Scimark.class.getName(), e);
         }
 
-        OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(
+        System.setProperty("test.noclasspath", "true");
+
+        OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createTestJvm(
             "-cp", artifacts.get("gov.nist.math.scimark-2.0").toString(),
             "jnt.scimark2.commandline", "-large")
             .start());


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314242](https://bugs.openjdk.org/browse/JDK-8314242) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314242](https://bugs.openjdk.org/browse/JDK-8314242): Update applications/scimark/Scimark.java to accept VM flags (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/302.diff">https://git.openjdk.org/jdk21u/pull/302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/302#issuecomment-1784966311)