### PR TITLE
8318474: Fix memory reporter for thread_count

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -233,7 +233,6 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
         MallocMemory* thread_stack_memory = _malloc_snapshot->by_type(mtThreadStack);
         const char* scale = current_scale();
         // report thread count
-        assert(ThreadStackTracker::thread_count() == 0, "Not used");
         out->print_cr("%27s (thread #" SIZE_FORMAT ")", " ", thread_stack_memory->malloc_count());
         out->print("%27s (Stack: " SIZE_FORMAT "%s", " ",
           amount_in_current_scale(thread_stack_memory->malloc_size()), scale);


### PR DESCRIPTION
Clean backport of [JDK-8318474](https://bugs.openjdk.org/browse/JDK-8318474)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8318474](https://bugs.openjdk.org/browse/JDK-8318474) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318474](https://bugs.openjdk.org/browse/JDK-8318474): Fix memory reporter for thread_count (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/311/head:pull/311` \
`$ git checkout pull/311`

Update a local copy of the PR: \
`$ git checkout pull/311` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 311`

View PR using the GUI difftool: \
`$ git pr show -t 311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/311.diff">https://git.openjdk.org/jdk21u/pull/311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/311#issuecomment-1787369647)