### PR TITLE
8314580: PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before"

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -767,7 +767,7 @@ SafePointNode* PhaseIdealLoop::find_safepoint(Node* back_control, Node* x, Ideal
 //     // inner_incr := AddI(inner_phi, intcon(stride))
 //     inner_incr = inner_phi + stride;
 //     if (inner_incr < inner_iters_actual) {
-//       ... use phi=>(outer_phi+inner_phi) and incr=>(outer_phi+inner_incr) ...
+//       ... use phi=>(outer_phi+inner_phi) ...
 //       continue;
 //     }
 //     else break;
@@ -977,10 +977,6 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   // loop iv phi
   Node* iv_add = loop_nest_replace_iv(phi, inner_phi, outer_phi, head, bt);
 
-  // Replace inner loop long iv incr with inner loop int incr + outer
-  // loop iv phi
-  loop_nest_replace_iv(incr, inner_incr, outer_phi, head, bt);
-
   set_subtree_ctrl(inner_iters_actual_int, body_populated);
 
   LoopNode* inner_head = create_inner_head(loop, head, exit_test);
@@ -1029,7 +1025,7 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   //       back_control: fallthrough;
   //     else
   //       inner_exit_branch: break;  //exit_branch->clone()
-  //     ... use phi=>(outer_phi+inner_phi) and incr=>(outer_phi+inner_incr) ...
+  //     ... use phi=>(outer_phi+inner_phi) ...
   //     inner_phi = inner_phi + stride;  // inner_incr
   //   }
   //   outer_exit_test:  //exit_test->clone(), in(0):=inner_exit_branch

--- a/test/hotspot/jtreg/compiler/rangechecks/TestLongRCWithLoopIncr.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestLongRCWithLoopIncr.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8314580
+ * @summary PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before"
+ * @run main/othervm -XX:-BackgroundCompilation TestLongRCWithLoopIncr
+ *
+ */
+
+import java.util.Objects;
+
+public class TestLongRCWithLoopIncr {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(1001);
+        }
+    }
+
+    private static void test(long length) {
+        for (long i = 0; i < 1000; i++) {
+            Objects.checkIndex(i + 1, length);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to improve C2 stability.

Additional testing:
 - [x] New regression test fails without fix, passes with it
 - [x] Linux AArch64 server fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314580](https://bugs.openjdk.org/browse/JDK-8314580) needs maintainer approval

### Issue
 * [JDK-8314580](https://bugs.openjdk.org/browse/JDK-8314580): PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/316/head:pull/316` \
`$ git checkout pull/316`

Update a local copy of the PR: \
`$ git checkout pull/316` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 316`

View PR using the GUI difftool: \
`$ git pr show -t 316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/316.diff">https://git.openjdk.org/jdk21u/pull/316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/316#issuecomment-1789318767)