### PR TITLE
8312434: SPECjvm2008/xml.transform with CDS fails with "can't seal package nu.xom"

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -368,7 +368,7 @@ void SharedClassPathEntry::copy_from(SharedClassPathEntry* ent, ClassLoaderData*
   _from_class_path_attr = ent->_from_class_path_attr;
   set_name(ent->name(), CHECK);
 
-  if (ent->is_jar() && !ent->is_signed() && ent->manifest() != nullptr) {
+  if (ent->is_jar() && ent->manifest() != nullptr) {
     Array<u1>* buf = MetadataFactory::new_array<u1>(loader_data,
                                                     ent->manifest_size(),
                                                     CHECK);
@@ -622,29 +622,6 @@ class ManifestStream: public ResourceObj {
     buf[len] = 0;
     return buf;
   }
-
-  // The return value indicates if the JAR is signed or not
-  bool check_is_signed() {
-    u1* attr = _current;
-    bool isSigned = false;
-    while (_current < _buffer_end) {
-      if (*_current == '\n') {
-        *_current = '\0';
-        u1* value = (u1*)strchr((char*)attr, ':');
-        if (value != nullptr) {
-          assert(*(value+1) == ' ', "Unrecognized format" );
-          if (strstr((char*)attr, "-Digest") != nullptr) {
-            isSigned = true;
-            break;
-          }
-        }
-        *_current = '\n'; // restore
-        attr = _current + 1;
-      }
-      _current ++;
-    }
-    return isSigned;
-  }
 };
 
 void FileMapInfo::update_jar_manifest(ClassPathEntry *cpe, SharedClassPathEntry* ent, TRAPS) {
@@ -657,18 +634,14 @@ void FileMapInfo::update_jar_manifest(ClassPathEntry *cpe, SharedClassPathEntry*
   if (manifest != nullptr) {
     ManifestStream* stream = new ManifestStream((u1*)manifest,
                                                 manifest_size);
-    if (stream->check_is_signed()) {
-      ent->set_is_signed();
-    } else {
-      // Copy the manifest into the shared archive
-      manifest = ClassLoaderExt::read_raw_manifest(THREAD, cpe, &manifest_size);
-      Array<u1>* buf = MetadataFactory::new_array<u1>(loader_data,
-                                                      manifest_size,
-                                                      CHECK);
-      char* p = (char*)(buf->data());
-      memcpy(p, manifest, manifest_size);
-      ent->set_manifest(buf);
-    }
+    // Copy the manifest into the shared archive
+    manifest = ClassLoaderExt::read_raw_manifest(THREAD, cpe, &manifest_size);
+    Array<u1>* buf = MetadataFactory::new_array<u1>(loader_data,
+                                                    manifest_size,
+                                                    CHECK);
+    char* p = (char*)(buf->data());
+    memcpy(p, manifest, manifest_size);
+    ent->set_manifest(buf);
   }
 }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -53,7 +53,6 @@ class SharedClassPathEntry : public MetaspaceObj {
   enum {
     modules_image_entry,
     jar_entry,
-    signed_jar_entry,
     dir_entry,
     non_existent_entry,
     unknown_entry
@@ -90,10 +89,6 @@ public:
   bool is_dir()           const { return _type == dir_entry; }
   bool is_modules_image() const { return _type == modules_image_entry; }
   bool is_jar()           const { return _type == jar_entry; }
-  bool is_signed()        const { return _type == signed_jar_entry; }
-  void set_is_signed() {
-    _type = signed_jar_entry;
-  }
   bool from_class_path_attr() { return _from_class_path_attr; }
   time_t timestamp() const { return _timestamp; }
   const char* name() const;

--- a/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8312434
+ * @summary A jar file containing classes in the same package. Sign the jar file with
+ *          a disabled algorithm. The jar will be treated as unsigned.
+ *          Dump only one class into the CDS archive. During runtime, load the class
+ *          stored in the archive and then load another class not from the archive
+ *          but from the same pacakge. Loading of the second class should not result
+ *          in sealing violation.
+ *
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/GenericTestApp.java test-classes/pkg/ClassInPackage.java test-classes/C2.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
+ * @run driver SealingViolation
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class SealingViolation {
+    public static void main(String[] args) throws Exception {
+        String[] classList = {"pkg/ClassInPackage"};
+        String appJar = ClassFileInstaller.writeJar("pkg-classes-sealed.jar",
+            ClassFileInstaller.Manifest.fromSourceFile("test-classes/pkg/package_seal.mf"),
+            "GenericTestApp", "pkg/ClassInPackage", "pkg/C2");
+
+        JarBuilder.signJarWithDisabledAlgorithm("pkg-classes-sealed");
+        String signedJar = TestCommon.getTestJar("pkg-classes-sealed.jar");
+
+        // GenericTestApp requires WhiteBox
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String bootclasspath = "-Xbootclasspath/a:" + wbJar;
+
+        OutputAnalyzer output = TestCommon.dump(signedJar, classList, bootclasspath,
+                                     "-Xlog:cds+class=debug");
+        output.shouldMatch("cds.class.*klasses.*app   pkg.ClassInPackage")
+              .shouldHaveExitValue(0);
+
+        output = TestCommon.exec(signedJar, "-Xlog:cds=debug,class+load",
+                                 bootclasspath,
+                                 "-XX:+UnlockDiagnosticVMOptions",
+                                 "-XX:+WhiteBoxAPI",
+                                 "GenericTestApp",
+                                 "assertShared:pkg.ClassInPackage",
+                                 "assertNotShared:pkg.C2");
+        output.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
@@ -38,7 +38,7 @@ import java.io.File;
 public class SignedJar {
     public static void main(String[] args) throws Exception {
         String unsignedJar = JarBuilder.getOrCreateHelloJar();
-        JarBuilder.signJar();
+        JarBuilder.signJar("hello");
 
         // Test class exists in signed JAR
         String signedJar = TestCommon.getTestJar("signed_hello.jar");

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/package_seal.mf
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/package_seal.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Created-By: 1.9.0-internal (Oracle Corporation)
+
+Name: pkg/
+Sealed: true
+


### PR DESCRIPTION
Clean backport.

Passed tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8312434](https://bugs.openjdk.org/browse/JDK-8312434) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312434](https://bugs.openjdk.org/browse/JDK-8312434): SPECjvm2008/xml.transform with CDS fails with "can't seal package nu.xom" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/322.diff">https://git.openjdk.org/jdk21u/pull/322.diff</a>

</details>
