### PR TITLE
8318736: com/sun/jdi/JdwpOnThrowTest.java failed with "transport error 202: bind failed: Address already in use"

### DIFF
--- a/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
+++ b/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
@@ -57,12 +57,11 @@ public class JdwpOnThrowTest {
     private static AttachingConnector attachingConnector;
 
     public static void main(String[] args) throws Exception {
-        int port = findFreePort();
-        try (Debuggee debuggee = Debuggee.launcher("ThrowCaughtException").setAddress("localhost:" + port)
-                                         .enableOnThrow("Ex", "Start").setSuspended(true).launch()) {
+        try (Debuggee debuggee = Debuggee.launcher("ThrowCaughtException")
+                                         .enableOnThrow("Ex").setSuspended(true).launch()) {
             VirtualMachine vm = null;
             try {
-                vm = attach("localhost", "" + port);
+                vm = attach("localhost", debuggee.getAddress());
                 EventQueue queue = vm.eventQueue();
                 log("Waiting for exception event");
                 long start = System.currentTimeMillis();
@@ -107,14 +106,6 @@ public class JdwpOnThrowTest {
         }
         if (!ex.exception().type().name().equals("Ex")) {
             throw new RuntimeException("Exception has wrong type: " + ex.exception().type().name());
-        }
-    }
-
-    private static int findFreePort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1a21c1a7](https://github.com/openjdk/jdk/commit/1a21c1a783d64ca0930c358c06a43975f96ffac6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Johannes Bechberger on 3 Nov 2023 and was reviewed by Alex Menkov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318736](https://bugs.openjdk.org/browse/JDK-8318736) needs maintainer approval

### Issue
 * [JDK-8318736](https://bugs.openjdk.org/browse/JDK-8318736): com/sun/jdi/JdwpOnThrowTest.java failed with "transport error 202: bind failed: Address already in use" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/331/head:pull/331` \
`$ git checkout pull/331`

Update a local copy of the PR: \
`$ git checkout pull/331` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 331`

View PR using the GUI difftool: \
`$ git pr show -t 331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/331.diff">https://git.openjdk.org/jdk21u/pull/331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/331#issuecomment-1798241610)