### PR TITLE
8318961: increase javacserver connection timeout values and max retry attempts

### DIFF
--- a/make/langtools/tools/javacserver/client/Client.java
+++ b/make/langtools/tools/javacserver/client/Client.java
@@ -51,9 +51,9 @@ import javacserver.util.Log;
 public class Client {
     private static final Log.Level LOG_LEVEL = Log.Level.INFO;
 
-    // Wait 2 seconds for response, before giving up on javac server.
-    private static final int CONNECTION_TIMEOUT = 2000;
-    private static final int MAX_CONNECT_ATTEMPTS = 3;
+    // Wait 4 seconds for response, before giving up on javac server.
+    private static final int CONNECTION_TIMEOUT = 4000;
+    private static final int MAX_CONNECT_ATTEMPTS = 10;
     private static final int WAIT_BETWEEN_CONNECT_ATTEMPTS = 2000;
 
     private final ClientConfiguration conf;
@@ -130,7 +130,7 @@ public class Client {
                 Log.error("Connection attempt failed: " + ex.getMessage());
                 if (attempt >= MAX_CONNECT_ATTEMPTS) {
                     Log.error("Giving up");
-                    throw new IOException("Could not connect to server", ex);
+                    throw new IOException("Could not connect to server after " + MAX_CONNECT_ATTEMPTS + " attempts with timeout " + CONNECTION_TIMEOUT, ex);
                 }
             }
             Thread.sleep(WAIT_BETWEEN_CONNECT_ATTEMPTS);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8318961](https://bugs.openjdk.org/browse/JDK-8318961) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318961](https://bugs.openjdk.org/browse/JDK-8318961): increase javacserver connection timeout values and max retry attempts (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/333/head:pull/333` \
`$ git checkout pull/333`

Update a local copy of the PR: \
`$ git checkout pull/333` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 333`

View PR using the GUI difftool: \
`$ git pr show -t 333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/333.diff">https://git.openjdk.org/jdk21u/pull/333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/333#issuecomment-1798565584)