### PR TITLE
8318525: Atomic gtest should run as TEST_VM to access VM capabilities

### DIFF
--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -53,7 +53,7 @@ struct AtomicAddTestSupport {
   }
 };
 
-TEST(AtomicAddTest, int32) {
+TEST_VM(AtomicAddTest, int32) {
   using Support = AtomicAddTestSupport<int32_t>;
   Support().test_add();
   Support().test_fetch_add();
@@ -61,14 +61,14 @@ TEST(AtomicAddTest, int32) {
 
 // 64bit Atomic::add is only supported on 64bit platforms.
 #ifdef _LP64
-TEST(AtomicAddTest, int64) {
+TEST_VM(AtomicAddTest, int64) {
   using Support = AtomicAddTestSupport<int64_t>;
   Support().test_add();
   Support().test_fetch_add();
 }
 #endif // _LP64
 
-TEST(AtomicAddTest, ptr) {
+TEST_VM(AtomicAddTest, ptr) {
   uint _test_values[10] = {};
   uint* volatile _test_value{};
 
@@ -103,14 +103,14 @@ struct AtomicXchgTestSupport {
   }
 };
 
-TEST(AtomicXchgTest, int32) {
+TEST_VM(AtomicXchgTest, int32) {
   using Support = AtomicXchgTestSupport<int32_t>;
   Support().test();
 }
 
 // 64bit Atomic::xchg is only supported on 64bit platforms.
 #ifdef _LP64
-TEST(AtomicXchgTest, int64) {
+TEST_VM(AtomicXchgTest, int64) {
   using Support = AtomicXchgTestSupport<int64_t>;
   Support().test();
 }
@@ -136,12 +136,12 @@ struct AtomicCmpxchgTestSupport {
   }
 };
 
-TEST(AtomicCmpxchgTest, int32) {
+TEST_VM(AtomicCmpxchgTest, int32) {
   using Support = AtomicCmpxchgTestSupport<int32_t>;
   Support().test();
 }
 
-TEST(AtomicCmpxchgTest, int64) {
+TEST_VM(AtomicCmpxchgTest, int64) {
   using Support = AtomicCmpxchgTestSupport<int64_t>;
   Support().test();
 }
@@ -186,7 +186,7 @@ struct AtomicCmpxchg1ByteStressSupport {
   }
 };
 
-TEST(AtomicCmpxchg1Byte, stress) {
+TEST_VM(AtomicCmpxchg1Byte, stress) {
   AtomicCmpxchg1ByteStressSupport support;
   support.test();
 }
@@ -224,7 +224,7 @@ namespace AtomicEnumTestUnscoped {       // Scope the enumerators.
   enum TestEnum { A, B, C };
 }
 
-TEST(AtomicEnumTest, unscoped_enum) {
+TEST_VM(AtomicEnumTest, unscoped_enum) {
   using namespace AtomicEnumTestUnscoped;
   using Support = AtomicEnumTestSupport<TestEnum>;
 
@@ -235,7 +235,7 @@ TEST(AtomicEnumTest, unscoped_enum) {
 
 enum class AtomicEnumTestScoped { A, B, C };
 
-TEST(AtomicEnumTest, scoped_enum) {
+TEST_VM(AtomicEnumTest, scoped_enum) {
   const AtomicEnumTestScoped B = AtomicEnumTestScoped::B;
   const AtomicEnumTestScoped C = AtomicEnumTestScoped::C;
   using Support = AtomicEnumTestSupport<AtomicEnumTestScoped>;
@@ -329,28 +329,28 @@ const T AtomicBitopsTestSupport<T>::_old_value;
 template<typename T>
 const T AtomicBitopsTestSupport<T>::_change_value;
 
-TEST(AtomicBitopsTest, int8) {
+TEST_VM(AtomicBitopsTest, int8) {
   AtomicBitopsTestSupport<int8_t>()();
 }
 
-TEST(AtomicBitopsTest, uint8) {
+TEST_VM(AtomicBitopsTest, uint8) {
   AtomicBitopsTestSupport<uint8_t>()();
 }
 
-TEST(AtomicBitopsTest, int32) {
+TEST_VM(AtomicBitopsTest, int32) {
   AtomicBitopsTestSupport<int32_t>()();
 }
 
-TEST(AtomicBitopsTest, uint32) {
+TEST_VM(AtomicBitopsTest, uint32) {
   AtomicBitopsTestSupport<uint32_t>()();
 }
 
 #ifdef _LP64
-TEST(AtomicBitopsTest, int64) {
+TEST_VM(AtomicBitopsTest, int64) {
   AtomicBitopsTestSupport<int64_t>()();
 }
 
-TEST(AtomicBitopsTest, uint64) {
+TEST_VM(AtomicBitopsTest, uint64) {
   AtomicBitopsTestSupport<uint64_t>()();
 }
 #endif // _LP64


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `gtest:Atomic` still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318525](https://bugs.openjdk.org/browse/JDK-8318525) needs maintainer approval

### Issue
 * [JDK-8318525](https://bugs.openjdk.org/browse/JDK-8318525): Atomic gtest should run as TEST_VM to access VM capabilities (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/339/head:pull/339` \
`$ git checkout pull/339`

Update a local copy of the PR: \
`$ git checkout pull/339` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 339`

View PR using the GUI difftool: \
`$ git pr show -t 339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/339.diff">https://git.openjdk.org/jdk21u/pull/339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/339#issuecomment-1802135370)