### PR TITLE
8316719: C2 compilation still fails with "bad AD file"

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
@@ -31,17 +31,41 @@ package compiler.c2;
  *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
  *                   compiler.c2.MinValueStrideCountedLoop
  */
+
+/*
+ * @test
+ * @bug 8316719
+ * @summary Loop increment should not be transformed into unsigned comparison
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-UseLoopPredicate
+ *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
+ *                   compiler.c2.MinValueStrideCountedLoop
+ */
 public class MinValueStrideCountedLoop {
     static int limit = 0;
     static int res = 0;
+    static int[] array = new int[1];
+    static boolean b;
 
-    static void test() {
+    static void test1() {
         for (int i = 0; i >= limit + -2147483647; i += -2147483648) {
             res += 42;
         }
     }
 
+    static int test2(int init, int limit) {
+        int res = 0;
+        int i = init;
+        do {
+            if (b) { }
+            res += array[i];
+            i += -2147483648;
+        } while (i >= limit + -2147483647);
+        return res;
+    }
+
     public static void main(String[] args) {
-        test();
+        test1();
+        test2(0, 0);
     }
 }


### PR DESCRIPTION
Clean backport to amend previous C2 regression fix. Applies cleanly.

Additional testing:
 - [x] New regression test fails without the fix, passes with it
 - [x] Linux x86_64 server fastdebug, `tier1 tier2 tier3 tier4`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316719](https://bugs.openjdk.org/browse/JDK-8316719) needs maintainer approval

### Issue
 * [JDK-8316719](https://bugs.openjdk.org/browse/JDK-8316719): C2 compilation still fails with "bad AD file" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/342/head:pull/342` \
`$ git checkout pull/342`

Update a local copy of the PR: \
`$ git checkout pull/342` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 342`

View PR using the GUI difftool: \
`$ git pr show -t 342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/342.diff">https://git.openjdk.org/jdk21u/pull/342.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/342#issuecomment-1803390235)