### PR TITLE
8315082: [REDO] Generational ZGC: Tests crash with assert(index == 0 || is_power_of_2(index))

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -134,12 +134,13 @@ int ArrayCopyNode::get_count(PhaseGVN *phase) const {
       assert (ary_src != nullptr, "not an array or instance?");
       // clone passes a length as a rounded number of longs. If we're
       // cloning an array we'll do it element by element. If the
-      // length input to ArrayCopyNode is constant, length of input
-      // array must be too.
-
-      assert((get_length_if_constant(phase) == -1) != ary_src->size()->is_con() ||
+      // length of the input array is constant, ArrayCopyNode::Length
+      // must be too. Note that the opposite does not need to hold,
+      // because different input array lengths (e.g. int arrays with
+      // 3 or 4 elements) might lead to the same length input
+      // (e.g. 2 double-words).
+      assert(!ary_src->size()->is_con() || (get_length_if_constant(phase) >= 0) ||
              phase->is_IterGVN() || phase->C->inlining_incrementally() || StressReflectiveCode, "inconsistent");
-
       if (ary_src->size()->is_con()) {
         return ary_src->size()->get_con();
       }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4992,8 +4992,8 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
       PreserveJVMState pjvms(this);
       set_control(array_ctl);
       Node* obj_length = load_array_length(obj);
-      Node* obj_size  = nullptr;
-      Node* alloc_obj = new_array(obj_klass, obj_length, 0, &obj_size, /*deoptimize_on_exception=*/true);
+      Node* array_size = nullptr; // Size of the array without object alignment padding.
+      Node* alloc_obj = new_array(obj_klass, obj_length, 0, &array_size, /*deoptimize_on_exception=*/true);
 
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       if (bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, false, BarrierSetC2::Parsing)) {
@@ -5026,7 +5026,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
       //  the object.)
 
       if (!stopped()) {
-        copy_to_clone(obj, alloc_obj, obj_size, true);
+        copy_to_clone(obj, alloc_obj, array_size, true);
 
         // Present the results of the copy.
         result_reg->init_req(_array_path, control());
@@ -5066,7 +5066,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
     if (!stopped()) {
       // It's an instance, and it passed the slow-path tests.
       PreserveJVMState pjvms(this);
-      Node* obj_size  = nullptr;
+      Node* obj_size = nullptr; // Total object size, including object alignment padding.
       // Need to deoptimize on exception from allocation since Object.clone intrinsic
       // is reexecuted if deoptimization occurs and there could be problems when merging
       // exception state between multiple Object.clone versions (reexecute=true vs reexecute=false).

--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneArrayWithDifferentLengthConstness.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneArrayWithDifferentLengthConstness.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy;
+
+/**
+ * @test
+ * @bug 8315082
+ * @summary Test that idealization of clone-derived ArrayCopy nodes does not
+ *          trigger assertion failures for different combinations of
+ *          constant/variable array length (in number of elements) and array
+ *          copy length (in words).
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileOnly=compiler.arraycopy.TestCloneArrayWithDifferentLengthConstness::test*
+ *                   compiler.arraycopy.TestCloneArrayWithDifferentLengthConstness
+ */
+
+public class TestCloneArrayWithDifferentLengthConstness {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            testConstantArrayLengthAndConstantArrayCopyLength();
+        }
+        for (int i = 0; i < 10_000; i++) {
+            testVariableArrayLengthAndConstantArrayCopyLength(i % 2 == 0);
+        }
+        for (int i = 0; i < 10_000; i++) {
+            testVariableArrayLengthAndVariableArrayCopyLength(i % 2 == 0);
+        }
+    }
+
+    static int[] testConstantArrayLengthAndConstantArrayCopyLength() {
+        int[] src = new int[3];
+        return (int[])src.clone();
+    }
+
+    static int[] testVariableArrayLengthAndConstantArrayCopyLength(boolean p) {
+        int[] src = new int[p ? 3 : 4];
+        return (int[])src.clone();
+    }
+
+    static int[] testVariableArrayLengthAndVariableArrayCopyLength(boolean p) {
+        int[] src = new int[p ? 3 : 42];
+        return (int[])src.clone();
+    }
+}

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestArrayCopyWithLargeObjectAlignment.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestArrayCopyWithLargeObjectAlignment.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.gcbarriers;
+
+import java.util.Arrays;
+
+/**
+ * @test
+ * @bug 8312749
+ * @summary Test that, when using a larger object alignment, ZGC arraycopy
+ *          barriers are only applied to actual OOPs, and not to object
+ *          alignment padding words.
+ * @requires vm.gc.ZGenerational
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileOnly=compiler.gcbarriers.TestArrayCopyWithLargeObjectAlignment::*
+ *                   -XX:ObjectAlignmentInBytes=16
+ *                   -XX:+UseZGC -XX:+ZGenerational
+ *                   compiler.gcbarriers.TestArrayCopyWithLargeObjectAlignment
+ */
+
+public class TestArrayCopyWithLargeObjectAlignment {
+
+    static Object[] doCopyOf(Object[] array) {
+        return Arrays.copyOf(array, array.length);
+    }
+
+    static Object[] doClone(Object[] array) {
+        return array.clone();
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            // This test allocates an array 'a', copies it into a new array 'b'
+            // using Arrays.copyOf, and clones 'b' into yet another array. For
+            // ObjectAlignmentInBytes=16, the intrinsic implementation of
+            // Arrays.copyOf leaves the object alignment padding word "b[1]"
+            // untouched, preserving the badHeapWordVal value '0xbaadbabe'. The
+            // test checks that this padding word is not processed as a valid
+            // OOP by the ZGC arraycopy stub underlying the intrinsic
+            // implementation of Object.clone. Allocating b using the intrinsic
+            // implementation of Arrays.copyOf is key to reproducing the issue
+            // because, unlike regular (fast or slow) array allocation,
+            // Arrays.copyOf does not zero-clear the padding word.
+            Object[] a = {new Object()};
+            Object[] b = doCopyOf(a);
+            doClone(b);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to improve GC reliability.

Additional testing:
 - [x] New regression tests pass with the fix, but also pass _without the fix too_
 - [x] Original reproducer from the issue fails before the fix, passes with it
 - [x] Linux x86_64 fastdebug, `tier1 tier2 tier3 tier4`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315082](https://bugs.openjdk.org/browse/JDK-8315082) needs maintainer approval

### Issue
 * [JDK-8315082](https://bugs.openjdk.org/browse/JDK-8315082): [REDO] Generational ZGC: Tests crash with assert(index == 0 || is_power_of_2(index)) (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/344.diff">https://git.openjdk.org/jdk21u/pull/344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/344#issuecomment-1803652456)