### PR TITLE
8316935: [s390x] Use consistent naming for lightweight locking in MacroAssembler

### DIFF
--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -107,7 +107,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   assert(LockingMode != LM_MONITOR, "LM_MONITOR is already handled, by emit_lock()");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(Roop, Rmark, tmp, slow_case);
+    lightweight_lock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     NearLabel done;
     // and mark it as unlocked.
@@ -171,7 +171,7 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
     z_lgr(tmp, Rmark);
     z_nill(tmp, markWord::monitor_value);
     z_brnz(slow_case);
-    fast_unlock(Roop, Rmark, tmp, slow_case);
+    lightweight_unlock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     // Test if object header is pointing to the displaced header, and if so, restore
     // the displaced header in the object. If the object header is not pointing to

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -1028,7 +1028,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   }
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(object, /* mark word */ header, tmp, slow_case);
+    lightweight_lock(object, /* mark word */ header, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
 
     // Set header to be (markWord of object | UNLOCK_VALUE).
@@ -1086,7 +1086,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   // slow case of monitor enter.
   bind(slow_case);
   if (LockingMode == LM_LIGHTWEIGHT) {
-    // for fast locking we need to use monitorenter_obj, see interpreterRuntime.cpp
+    // for lightweight locking we need to use monitorenter_obj, see interpreterRuntime.cpp
     call_VM(noreg,
             CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter_obj),
             object);
@@ -1185,7 +1185,7 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
     z_nill(tmp, markWord::monitor_value);
     z_brne(slow_case);
 
-    fast_unlock(object, header, tmp, slow_case);
+    lightweight_unlock(object, header, tmp, slow_case);
 
     z_bru(done);
   } else {

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3204,7 +3204,7 @@ void MacroAssembler::compiler_fast_lock_object(Register oop, Register box, Regis
     z_bru(done);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-    fast_lock(oop, displacedHeader, temp, done);
+    lightweight_lock(oop, displacedHeader, temp, done);
     z_bru(done);
   }
 
@@ -3284,7 +3284,7 @@ void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Reg
     // don't load currentHead again from stack-top after monitor check, as it is possible
     // some other thread modified it.
     // currentHeader is altered, but it's contents are copied in temp as well
-    fast_unlock(oop, temp, currentHeader, done);
+    lightweight_unlock(oop, temp, currentHeader, done);
     z_bru(done);
   }
 
@@ -5644,14 +5644,14 @@ SkipIfEqual::~SkipIfEqual() {
   _masm->bind(_label);
 }
 
-// Implements fast-locking.
+// Implements lightweight-locking.
 // Branches to slow upon failure to lock the object.
 // Falls through upon success.
 //
 //  - obj: the object to be locked, contents preserved.
 //  - hdr: the header, already loaded from obj, contents destroyed.
 //  Note: make sure Z_R1 is not manipulated here when C2 compiler is in play
-void MacroAssembler::fast_lock(Register obj, Register hdr, Register temp, Label& slow_case) {
+void MacroAssembler::lightweight_lock(Register obj, Register hdr, Register temp, Label& slow_case) {
 
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, temp);
@@ -5661,7 +5661,7 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register temp, Label&
 
   compareU32_and_branch(temp, (unsigned)LockStack::end_offset()-1, bcondHigh, slow_case);
 
-  // attempting a fast_lock
+  // attempting a lightweight_lock
   // Load (object->mark() | 1) into hdr
   z_oill(hdr, markWord::unlocked_value);
 
@@ -5683,26 +5683,26 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register temp, Label&
   z_cr(temp, temp);
 }
 
-// Implements fast-unlocking.
+// Implements lightweight-unlocking.
 // Branches to slow upon failure.
 // Falls through upon success.
 //
 // - obj: the object to be unlocked
 // - hdr: the (pre-loaded) header of the object, will be destroyed
 // - Z_R1_scratch: will be killed in case of Interpreter & C1 Compiler
-void MacroAssembler::fast_unlock(Register obj, Register hdr, Register tmp, Label& slow) {
+void MacroAssembler::lightweight_unlock(Register obj, Register hdr, Register tmp, Label& slow) {
 
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, tmp);
 
 #ifdef ASSERT
   {
-    // Check that hdr is fast-locked.
+    // Check that hdr is lightweight-locked.
     Label hdr_ok;
     z_lgr(tmp, hdr);
     z_nill(tmp, markWord::lock_mask_in_place);
     z_bre(hdr_ok);
-    stop("Header is not fast-locked");
+    stop("Header is not lightweight-locked");
     bind(hdr_ok);
   }
   {

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -722,8 +722,8 @@ class MacroAssembler: public Assembler {
 
   void compiler_fast_lock_object(Register oop, Register box, Register temp1, Register temp2);
   void compiler_fast_unlock_object(Register oop, Register box, Register temp1, Register temp2);
-  void fast_lock(Register obj, Register hdr, Register tmp, Label& slow);
-  void fast_unlock(Register obj, Register hdr, Register tmp, Label& slow);
+  void lightweight_lock(Register obj, Register hdr, Register tmp, Label& slow);
+  void lightweight_unlock(Register obj, Register hdr, Register tmp, Label& slow);
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [efb7e85e](https://github.com/openjdk/jdk/commit/efb7e85ecfc9c6edb2820e1bf72d48958d4c9780) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 26 Sep 2023 and was reviewed by Martin Doerr and Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316935](https://bugs.openjdk.org/browse/JDK-8316935) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316935](https://bugs.openjdk.org/browse/JDK-8316935): [s390x] Use consistent naming for lightweight locking in MacroAssembler (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/345.diff">https://git.openjdk.org/jdk21u/pull/345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/345#issuecomment-1804085772)