### PR TITLE
8316436: ContinuationWrapper uses unhandled nullptr oop

### DIFF
--- a/src/hotspot/share/runtime/continuationWrapper.cpp
+++ b/src/hotspot/share/runtime/continuationWrapper.cpp
@@ -38,16 +38,12 @@
 #include "runtime/stackChunkFrameStream.inline.hpp"
 
 ContinuationWrapper::ContinuationWrapper(const RegisterMap* map)
-  : _thread(map->thread()),
-    _entry(Continuation::get_continuation_entry_for_continuation(_thread, map->stack_chunk()->cont())),
-    _continuation(map->stack_chunk()->cont())
-  {
-  assert(oopDesc::is_oop(_continuation),"Invalid cont: " INTPTR_FORMAT, p2i((void*)_continuation));
+  : ContinuationWrapper(map->thread(),
+                        Continuation::get_continuation_entry_for_continuation(map->thread(), map->stack_chunk()->cont()),
+                        map->stack_chunk()->cont()) {
   assert(_entry == nullptr || _continuation == _entry->cont_oop(map->thread()),
     "cont: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
     p2i( (oopDesc*)_continuation), p2i((oopDesc*)_entry->cont_oop(map->thread())), p2i(entrySP()));
-  disallow_safepoint();
-  read();
 }
 
 const frame ContinuationWrapper::last_frame() {
@@ -96,4 +92,3 @@ bool ContinuationWrapper::chunk_invariant() const {
   return true;
 }
 #endif // ASSERT
-


### PR DESCRIPTION
Clean backport to improve Loom code reliability.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `jdk_loom hotspot_loom`
 - [x] Linux x86_64 server fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316436](https://bugs.openjdk.org/browse/JDK-8316436) needs maintainer approval

### Issue
 * [JDK-8316436](https://bugs.openjdk.org/browse/JDK-8316436): ContinuationWrapper uses unhandled nullptr oop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/346/head:pull/346` \
`$ git checkout pull/346`

Update a local copy of the PR: \
`$ git checkout pull/346` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 346`

View PR using the GUI difftool: \
`$ git pr show -t 346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/346.diff">https://git.openjdk.org/jdk21u/pull/346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/346#issuecomment-1804398684)