### PR TITLE
8312191: ColorConvertOp.filter for the default destination is too slow

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -560,7 +560,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
                         "Destination ColorSpace is undefined");
                 }
                 ICC_Profile destProfile = profileList[nProfiles - 1];
-                cs = new ICC_ColorSpace(destProfile);
+                cs = createCompatibleColorSpace(destProfile);
             } else {
                 /* non-ICC case */
                 int nSpaces = CSList.length;
@@ -568,6 +568,25 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
             }
         }
         return createCompatibleDestImage(src, destCM, cs);
+    }
+
+    private static ColorSpace createCompatibleColorSpace(ICC_Profile profile) {
+        if (profile == ICC_Profile.getInstance(ColorSpace.CS_sRGB)) {
+            return ColorSpace.getInstance(ColorSpace.CS_sRGB);
+        }
+        if (profile == ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB)) {
+            return ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB);
+        }
+        if (profile == ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ)) {
+            return ColorSpace.getInstance(ColorSpace.CS_CIEXYZ);
+        }
+        if (profile == ICC_Profile.getInstance(ColorSpace.CS_PYCC)) {
+            return ColorSpace.getInstance(ColorSpace.CS_PYCC);
+        }
+        if (profile == ICC_Profile.getInstance(ColorSpace.CS_GRAY)) {
+            return ColorSpace.getInstance(ColorSpace.CS_GRAY);
+        }
+        return new ICC_ColorSpace(profile);
     }
 
     private BufferedImage createCompatibleDestImage(BufferedImage src,

--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/CompatibleColorSpace.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/CompatibleColorSpace.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+
+/**
+ * @test
+ * @bug 8312191
+ * @summary Standard color spaces should be reused for CompatibleDestImage
+ */
+public final class CompatibleColorSpace {
+
+    private static final int[] spaces = {
+            ColorSpace.CS_CIEXYZ, ColorSpace.CS_GRAY, ColorSpace.CS_LINEAR_RGB,
+            ColorSpace.CS_PYCC, ColorSpace.CS_sRGB
+    };
+
+    public static void main(String[] args) {
+        for (int from : spaces) {
+            for (int to : spaces) {
+                test(from, to);
+            }
+        }
+    }
+
+    private static void test(int from, int to) {
+        ColorSpace srcCS = ColorSpace.getInstance(from);
+        ColorSpace dstCS = ColorSpace.getInstance(to);
+        ColorConvertOp op = new ColorConvertOp(srcCS, dstCS, null);
+        BufferedImage src = new BufferedImage(10, 10,
+                                              BufferedImage.TYPE_INT_ARGB);
+        BufferedImage dst = op.filter(src, null);
+        // dst image is not set and will be created automatically, the dstCS
+        // should be reused
+        if (dst.getColorModel().getColorSpace() != dstCS) {
+            throw new RuntimeException("Wrong color space");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e5f05b5a](https://github.com/openjdk/jdk/commit/e5f05b5a963774914751d9c241dd5693ed06af0b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 25 Sep 2023 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312191](https://bugs.openjdk.org/browse/JDK-8312191) needs maintainer approval

### Issue
 * [JDK-8312191](https://bugs.openjdk.org/browse/JDK-8312191): ColorConvertOp.filter for the default destination is too slow (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/347/head:pull/347` \
`$ git checkout pull/347`

Update a local copy of the PR: \
`$ git checkout pull/347` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 347`

View PR using the GUI difftool: \
`$ git pr show -t 347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/347.diff">https://git.openjdk.org/jdk21u/pull/347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/347#issuecomment-1804790881)