### PR TITLE
8319828: runtime/NMT/VirtualAllocCommitMerge.java may fail if mixing interpreted and compiled native invocations

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
@@ -24,12 +24,15 @@
 /*
  * @test
  * @summary Test merging of committed virtual memory and that we track it correctly
+ * @comment needs to be executed with -Xint (or, alternatively, -Xcomp -Xbatch) since it relies on comparing
+ *          NMT call stacks, and we must make sure that all functions on the stack that NMT sees are either compiled
+ *          from the get-go or stay always interpreted.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail VirtualAllocCommitMerge
+ * @run main/othervm -Xbootclasspath/a:. -Xint -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail VirtualAllocCommitMerge
  *
  */
 


### PR DESCRIPTION
Fixes intermittent test errors in the runtime NMT test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319828](https://bugs.openjdk.org/browse/JDK-8319828) needs maintainer approval

### Issue
 * [JDK-8319828](https://bugs.openjdk.org/browse/JDK-8319828): runtime/NMT/VirtualAllocCommitMerge.java may fail if mixing interpreted and compiled native invocations (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/349.diff">https://git.openjdk.org/jdk21u/pull/349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/349#issuecomment-1805782898)