### PR TITLE
8319104: GtestWrapper crashes with SIGILL in AsyncLogTest::test_asynclog_raw on AIX opt

### DIFF
--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -31,7 +31,7 @@
 #include "unittest.hpp"
 
 // Test the default level for each tagset
-TEST(LogTagSet, defaults) {
+TEST_VM(LogTagSet, defaults) {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     char buf[256];
     ts->label(buf, sizeof(buf));
@@ -44,7 +44,7 @@ TEST(LogTagSet, defaults) {
   }
 }
 
-TEST(LogTagSet, has_output) {
+TEST_VM(LogTagSet, has_output) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   ts.set_output_level(StderrLog, LogLevel::Trace);
   EXPECT_TRUE(ts.has_output(StderrLog));
@@ -53,14 +53,14 @@ TEST(LogTagSet, has_output) {
   EXPECT_FALSE(ts.has_output(StderrLog));
 }
 
-TEST(LogTagSet, ntags) {
+TEST_VM(LogTagSet, ntags) {
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   EXPECT_EQ(1u, ts.ntags());
   const LogTagSet& ts2 = LogTagSetMapping<LOG_TAGS(logging, gc, class, safepoint, heap)>::tagset();
   EXPECT_EQ(5u, ts2.ntags());
 }
 
-TEST(LogTagSet, is_level) {
+TEST_VM(LogTagSet, is_level) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   // Set info level on stdout and verify that is_level() reports correctly
   ts.set_output_level(StdoutLog, LogLevel::Info);
@@ -71,9 +71,10 @@ TEST(LogTagSet, is_level) {
   EXPECT_FALSE(ts.is_level(LogLevel::Trace));
   ts.set_output_level(StdoutLog, LogLevel::Default);
   EXPECT_TRUE(ts.is_level(LogLevel::Default));
+  ts.set_output_level(StdoutLog, LogLevel::Off);
 }
 
-TEST(LogTagSet, level_for) {
+TEST_VM(LogTagSet, level_for) {
   LogOutput* output = StdoutLog;
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   for (uint i = 0; i < LogLevel::Count; i++) {
@@ -82,10 +83,10 @@ TEST(LogTagSet, level_for) {
     ts.set_output_level(output, level);
     EXPECT_EQ(level, ts.level_for(output));
   }
-  ts.set_output_level(output, LogLevel::Default);
+  ts.set_output_level(output, LogLevel::Off);
 }
 
-TEST(LogTagSet, contains) {
+TEST_VM(LogTagSet, contains) {
   // Verify that contains works as intended for a few predetermined tagsets
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   EXPECT_TRUE(ts.contains(PREFIX_LOG_TAG(logging)));
@@ -111,7 +112,7 @@ TEST(LogTagSet, contains) {
   EXPECT_TRUE(ts4.contains(PREFIX_LOG_TAG(heap)));
 }
 
-TEST(LogTagSet, label) {
+TEST_VM(LogTagSet, label) {
   char buf[256];
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging, safepoint)>::tagset();
   ASSERT_NE(-1, ts.label(buf, sizeof(buf)));
@@ -137,7 +138,7 @@ TEST(LogTagSet, label) {
 
 }
 
-TEST(LogTagSet, duplicates) {
+TEST_VM(LogTagSet, duplicates) {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     char ts_name[512];
     ts->label(ts_name, sizeof(ts_name), ",");


### PR DESCRIPTION
Backporting to fix tests for AIX.

Had to remove LogConfiguration:: because [8299825](https://bugs.openjdk.org/browse/JDK-8299825)
Move StdoutLog and StderrLog to LogConfiguration is not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319104](https://bugs.openjdk.org/browse/JDK-8319104) needs maintainer approval

### Issue
 * [JDK-8319104](https://bugs.openjdk.org/browse/JDK-8319104): GtestWrapper crashes with SIGILL in AsyncLogTest::test_asynclog_raw on AIX opt (**Bug** - P3 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/350.diff">https://git.openjdk.org/jdk21u/pull/350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/350#issuecomment-1805624657)