### PR TITLE
JDK-8319922: libCreationTimeHelper.so fails to link in JDK 21

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -133,7 +133,7 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libFib := -g
   BUILD_JDK_JTREG_LIBRARIES_STRIP_SYMBOLS_libFib := false
   # nio tests' libCreationTimeHelper native needs -ldl linker flag
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libCreationTimeHelper := -ldl
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libCreationTimeHelper := -ldl
 endif
 
 ifeq ($(ASAN_ENABLED), true)


### PR DESCRIPTION
JDK 21 specific patch to fix a build error when building JTreg test libraries.

Details see JBS issue.

Ping @jerboaa

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319922](https://bugs.openjdk.org/browse/JDK-8319922) needs maintainer approval

### Issue
 * [JDK-8319922](https://bugs.openjdk.org/browse/JDK-8319922): libCreationTimeHelper.so fails to link in JDK 21 (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/351/head:pull/351` \
`$ git checkout pull/351`

Update a local copy of the PR: \
`$ git checkout pull/351` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 351`

View PR using the GUI difftool: \
`$ git pr show -t 351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/351.diff">https://git.openjdk.org/jdk21u/pull/351.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/351#issuecomment-1805770236)