### PR TITLE
8316003: Update FileChooserSymLinkTest.java to HTML instructions

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,48 +74,61 @@ public class FileChooserSymLinkTest {
     static void initialize() throws InterruptedException, InvocationTargetException {
         //Initialize the components
         final String INSTRUCTIONS = """
+                <html><body>
                 Instructions to Test:
-                1. Open an elevated Command Prompt.
-                2. Paste the following commands:
-                cd /d C:\\
+                <ol>
+                <li>Open an elevated <i>Command Prompt</i>.
+                <li>Paste the following commands:
+                <pre><code>cd /d C:\\
                 mkdir FileChooserTest
                 cd FileChooserTest
                 mkdir target
-                mklink /d link target
+                mklink /d link target</code></pre>
 
-                3. Navigate to C:\\FileChooserTest in the JFileChooser.
-                4. Use "Enable Multi-Selection" checkbox to enable/disable
-                   MultiSelection Mode
-                5. Single-selection:
-                   Click "link" directory, the absolute path of the symbolic
-                   link should be displayed. If it's null, click FAIL.
-                   Click "target" directory, its absolute path should be
-                   displayed.
-
-                   Enable multiple selection by clicking the checkbox.
-                   Multi-selection:
-                   Click "link", press Ctrl and then click "target".
-                   Both should be selected and their absolute paths should be
-                   displayed.
-
-                   If "link" can't be selected or if its absolute path is null,
-                   click FAIL.
-
-                   If "link" can be selected in both single- and multi-selection modes,
-                   click PASS.
-                6. When done with testing, paste the following commands to
-                   remove the 'FileChooserTest' directory:
-                cd \\
-                rmdir /s /q C:\\FileChooserTest
+                <li>Navigate to <code>C:\\FileChooserTest</code> in
+                    the <code>JFileChooser</code>.
+                <li>Perform testing in single- and multi-selection modes:
+                    <ul style="margin-bottom: 0px">
+                    <li><strong>Single-selection:</strong>
+                        <ol>
+                        <li>Ensure <b>Enable multi-selection</b> is cleared
+                            (the default state).
+                        <li>Click <code>link</code> directory,
+                            the absolute path of the symbolic
+                            link should be displayed.<br>
+                            If it's <code>null</code>, click <b>Fail</b>.
+                        <li>Click <code>target</code> directory,
+                            its absolute path should be displayed.
+                        </ol>
+                    <li><strong>Multi-selection:</strong>
+                        <ol>
+                        <li>Select <b>Enable multi-selection</b>.
+                        <li>Click <code>link</code>,
+                        <li>Press <kbd>Ctrl</kbd> and
+                            then click <code>target</code>.
+                        <li>Both should be selected and
+                            their absolute paths should be displayed.
+                        <li>If <code>link</code> can't be selected or
+                            if its absolute path is <code>null</code>,
+                            click <b>Fail</b>.
+                        </ol>
+                    </ul>
+                    <p>If <code>link</code> can be selected in both
+                    single- and multi-selection modes, click <b>Pass</b>.</p>
+                <li>When done with testing, paste the following commands to
+                    remove the <code>FileChooserTest</code> directory:
+                <pre><code>cd \\
+                rmdir /s /q C:\\FileChooserTest</code></pre>
 
                 or use File Explorer to clean it up.
+                </ol>
                 """;
         frame = new JFrame("JFileChooser Symbolic Link test");
         panel = new JPanel(new BorderLayout());
         multiSelection = new JCheckBox("Enable Multi-Selection");
         pathList = new JTextArea(10, 50);
         jfc = new JFileChooser(new File("C:\\"));
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 40);
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 50);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);


### PR DESCRIPTION
Backports an example of using HTML formatting in `PassFailJFrame`.

This is a clean backport. It depends on [JDK-8294158](https://bugs.openjdk.org/browse/JDK-8294158) being already integrated, see #352.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316003](https://bugs.openjdk.org/browse/JDK-8316003) needs maintainer approval

### Issue
 * [JDK-8316003](https://bugs.openjdk.org/browse/JDK-8316003): Update FileChooserSymLinkTest.java to HTML instructions (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/353/head:pull/353` \
`$ git checkout pull/353`

Update a local copy of the PR: \
`$ git checkout pull/353` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 353`

View PR using the GUI difftool: \
`$ git pr show -t 353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/353.diff">https://git.openjdk.org/jdk21u/pull/353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/353#issuecomment-1805956719)