### PR TITLE
8319339: Internal error on spurious markup in a hybrid snippet

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,9 +264,11 @@ public class SnippetTaglet extends BaseTaglet {
         StyledText externalSnippet = null;
 
         try {
-            Diags d = (text, pos) -> {
+            Diags d = (key, pos) -> {
                 var path = writer.configuration().utils.getCommentHelper(holder)
                         .getDocTreePath(snippetTag.getBody());
+                var resources = writer.configuration().getDocResources();
+                var text = resources.getText(key);
                 writer.configuration().getReporter().print(Diagnostic.Kind.WARNING,
                         path, pos, pos, pos, text);
             };
@@ -286,7 +288,7 @@ public class SnippetTaglet extends BaseTaglet {
 
         try {
             var finalFileObject = fileObject;
-            Diags d = (text, pos) -> writer.configuration().getMessages().warning(finalFileObject, pos, pos, pos, text);
+            Diags d = (key, pos) -> writer.configuration().getMessages().warning(finalFileObject, pos, pos, pos, key);
             if (externalContent != null) {
                 externalSnippet = parse(writer.configuration().getDocResources(), d, language, externalContent);
             }
@@ -373,7 +375,7 @@ public class SnippetTaglet extends BaseTaglet {
     }
 
     public interface Diags {
-        void warn(String text, int pos);
+        void warn(String key, int pos);
     }
 
     private static String stringValueOf(AttributeTree at) throws BadSnippetException {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public final class Parser {
                     }
                 }
                 if (parsedTags.isEmpty()) { // (2)
-                    diags.warn(resources.getText("doclet.snippet.markup.spurious"), next.offset() + markedUpLine.start("markup"));
+                    diags.warn("doclet.snippet.markup.spurious", next.offset() + markedUpLine.start("markup"));
                     line = rawLine + (addLineTerminator ? "\n" : "");
                 } else { // (3)
                     hasMarkup = true;


### PR DESCRIPTION
Please review this backport of JDK-8319339 ([c9077b8b](https://github.com/openjdk/jdk/commit/c9077b8b816d2efe4559c71341228a8dc319604f)) to jdk21u.

This backport is not clean because of [e51472e9](https://github.com/openjdk/jdk/commit/e51472e9a857451451d6df37588bd67f63bc2032), which is absent in jdk21u, but does not need to be backported. The conflict was simple and easily resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319339](https://bugs.openjdk.org/browse/JDK-8319339) needs maintainer approval

### Issue
 * [JDK-8319339](https://bugs.openjdk.org/browse/JDK-8319339): Internal error on spurious markup in a hybrid snippet (**Bug** - P4 - Approved)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/354/head:pull/354` \
`$ git checkout pull/354`

Update a local copy of the PR: \
`$ git checkout pull/354` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 354`

View PR using the GUI difftool: \
`$ git pr show -t 354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/354.diff">https://git.openjdk.org/jdk21u/pull/354.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/354#issuecomment-1808250071)