### PR TITLE
8315545: C1: x86 cmove can use short branches

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -2047,7 +2047,7 @@ void LIR_Assembler::cmove(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, L
 
   } else {
     Label skip;
-    __ jcc (acond, skip);
+    __ jccb(acond, skip);
     if (opr2->is_cpu_register()) {
       reg2reg(opr2, result);
     } else if (opr2->is_stack()) {


### PR DESCRIPTION
Clean backport to improve generated code density.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3 tier4`, `-XX:TieredStopAtLevel=1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315545](https://bugs.openjdk.org/browse/JDK-8315545) needs maintainer approval

### Issue
 * [JDK-8315545](https://bugs.openjdk.org/browse/JDK-8315545): C1: x86 cmove can use short branches (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/356.diff">https://git.openjdk.org/jdk21u/pull/356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/356#issuecomment-1809068432)