### PR TITLE
8317581: [s390x] Multiple test failure with LockingMode=2

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -140,7 +140,8 @@ class RelAddr {
     if ((target == nullptr) || (target == pc)) {
       return 0;  // Yet unknown branch destination.
     } else {
-      guarantee(is_in_range_of_RelAddr(target, pc, shortForm), "target not within reach");
+      guarantee(is_in_range_of_RelAddr(target, pc, shortForm),
+                "target not within reach at " INTPTR_FORMAT ", distance = " INTX_FORMAT, p2i(pc), (target - pc) );
       return (int)((target - pc)>>1);
     }
   }

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -101,7 +101,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(tmp, Roop);
     testbit(Address(tmp, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
-    z_btrue(slow_case);
+    branch_optimized(Assembler::bcondAllOne, slow_case);
   }
 
   assert(LockingMode != LM_MONITOR, "LM_MONITOR is already handled, by emit_lock()");
@@ -170,7 +170,7 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
     z_lg(Rmark, Address(Roop, hdr_offset));
     z_lgr(tmp, Rmark);
     z_nill(tmp, markWord::monitor_value);
-    z_brnz(slow_case);
+    branch_optimized(Assembler::bcondNotZero, slow_case);
     lightweight_unlock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     // Test if object header is pointing to the displaced header, and if so, restore


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [839cb19e](https://github.com/openjdk/jdk/commit/839cb19ec29e3803c834ca60697943aee580569f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 12 Oct 2023 and was reviewed by Thomas Stuefe and Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317581](https://bugs.openjdk.org/browse/JDK-8317581) needs maintainer approval

### Issue
 * [JDK-8317581](https://bugs.openjdk.org/browse/JDK-8317581): [s390x] Multiple test failure with LockingMode=2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/362/head:pull/362` \
`$ git checkout pull/362`

Update a local copy of the PR: \
`$ git checkout pull/362` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 362`

View PR using the GUI difftool: \
`$ git pr show -t 362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/362.diff">https://git.openjdk.org/jdk21u/pull/362.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/362#issuecomment-1810580810)