### PR TITLE
8319958: test/jdk/java/io/File/libGetXSpace.c does not compile on Windows 32-bit

### DIFF
--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include "jni.h"
 #include "jni_util.h"
-#ifdef _WIN64
+#ifdef WINDOWS
 #include <windows.h>
 #include <fileapi.h>
 #include <winerror.h>
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#ifdef _WIN64
+#ifdef WINDOWS
 jboolean initialized = JNI_FALSE;
 BOOL(WINAPI * pfnGetDiskSpaceInformation)(LPCWSTR, LPVOID) = NULL;
 #endif
@@ -67,7 +67,7 @@ Java_GetXSpace_getSpace0
         return JNI_FALSE;
     }
 
-#ifdef _WIN64
+#ifdef WINDOWS
     if (initialized == JNI_FALSE) {
         initialized = JNI_TRUE;
         HMODULE hmod = GetModuleHandleW(L"kernel32");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319958](https://bugs.openjdk.org/browse/JDK-8319958) needs maintainer approval

### Issue
 * [JDK-8319958](https://bugs.openjdk.org/browse/JDK-8319958): test/jdk/java/io/File/libGetXSpace.c does not compile on Windows 32-bit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/364/head:pull/364` \
`$ git checkout pull/364`

Update a local copy of the PR: \
`$ git checkout pull/364` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 364`

View PR using the GUI difftool: \
`$ git pr show -t 364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/364.diff">https://git.openjdk.org/jdk21u/pull/364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/364#issuecomment-1810993614)