### PR TITLE
8318240: [AIX] Cleaners.java test failure

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -104,6 +104,9 @@ public final class SunNativeProvider extends Provider {
                                         // Full path needed, DLL is in jre/bin
                                         StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
                                 };
+                                case AIX -> new String[]{
+                                        "/opt/freeware/lib64/libgssapi_krb5.so",
+                                };
                                 default -> new String[0];
                             };
                         } else {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8318240](https://bugs.openjdk.org/browse/JDK-8318240), commit [d4b76124](https://github.com/openjdk/jdk/commit/d4b761242d91aa1bcadc438cce0a9465c0f8b23d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Varada M on 24 Oct 2023 and was reviewed by Matthias Baesken and Andreas Steiner.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318240](https://bugs.openjdk.org/browse/JDK-8318240) needs maintainer approval

### Issue
 * [JDK-8318240](https://bugs.openjdk.org/browse/JDK-8318240): [AIX] Cleaners.java test failure (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/365/head:pull/365` \
`$ git checkout pull/365`

Update a local copy of the PR: \
`$ git checkout pull/365` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 365`

View PR using the GUI difftool: \
`$ git pr show -t 365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/365.diff">https://git.openjdk.org/jdk21u/pull/365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/365#issuecomment-1811382489)