### PR TITLE
8320053: GHA: Cross-compile gtest code

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -100,6 +100,10 @@ jobs:
         with:
           platform: linux-x64
 
+      - name: 'Get GTest'
+        id: gtest
+        uses: ./.github/actions/get-gtest
+
         # Upgrading apt to solve libc6 installation bugs, see JDK-8260460.
       - name: 'Install toolchain and dependencies'
         run: |
@@ -155,6 +159,7 @@ jobs:
           --with-conf-name=linux-${{ matrix.target-cpu }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
+          --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --enable-debug
           --disable-precompiled-headers


### PR DESCRIPTION
Clean backport to improve GHA coverage.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320053](https://bugs.openjdk.org/browse/JDK-8320053) needs maintainer approval

### Issue
 * [JDK-8320053](https://bugs.openjdk.org/browse/JDK-8320053): GHA: Cross-compile gtest code (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/368/head:pull/368` \
`$ git checkout pull/368`

Update a local copy of the PR: \
`$ git checkout pull/368` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 368`

View PR using the GUI difftool: \
`$ git pr show -t 368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/368.diff">https://git.openjdk.org/jdk21u/pull/368.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/368#issuecomment-1814095297)