### PR TITLE
8319961: JvmtiEnvBase doesn't zero _ext_event_callbacks

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -213,7 +213,8 @@ JvmtiEnvBase::JvmtiEnvBase(jint version) : _env_event_enable() {
   _is_retransformable = true;
 
   // all callbacks initially null
-  memset(&_event_callbacks,0,sizeof(jvmtiEventCallbacks));
+  memset(&_event_callbacks, 0, sizeof(jvmtiEventCallbacks));
+  memset(&_ext_event_callbacks, 0, sizeof(jvmtiExtEventCallbacks));
 
   // all capabilities initially off
   memset(&_current_capabilities, 0, sizeof(_current_capabilities));


### PR DESCRIPTION
Clean backport, no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319961](https://bugs.openjdk.org/browse/JDK-8319961) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319961](https://bugs.openjdk.org/browse/JDK-8319961): JvmtiEnvBase doesn't zero _ext_event_callbacks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/370/head:pull/370` \
`$ git checkout pull/370`

Update a local copy of the PR: \
`$ git checkout pull/370` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 370`

View PR using the GUI difftool: \
`$ git pr show -t 370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/370.diff">https://git.openjdk.org/jdk21u/pull/370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/370#issuecomment-1814378736)