### PR TITLE
8318981: compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with 'disallowed by CompileCommand' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -40,6 +40,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestConflictInlineCommands {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Xbatch",
                 "-XX:CompileCommand=inline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=dontinline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*Launcher::main",


### PR DESCRIPTION
Backport 8318981

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8318981](https://bugs.openjdk.org/browse/JDK-8318981) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318981](https://bugs.openjdk.org/browse/JDK-8318981): compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with 'disallowed by CompileCommand' missing from stdout/stderr (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/373/head:pull/373` \
`$ git checkout pull/373`

Update a local copy of the PR: \
`$ git checkout pull/373` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 373`

View PR using the GUI difftool: \
`$ git pr show -t 373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/373.diff">https://git.openjdk.org/jdk21u/pull/373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/373#issuecomment-1814801030)