### PR TITLE
8320209: VectorMaskGen clobbers rflags on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8985,9 +8985,9 @@ instruct vmask_cmp_node(rRegI dst, vec src1, vec src2, kReg mask, kReg ktmp1, kR
 %}
 
 
-instruct vmask_gen(kReg dst, rRegL len, rRegL temp) %{
+instruct vmask_gen(kReg dst, rRegL len, rRegL temp, rFlagsReg cr) %{
   match(Set dst (VectorMaskGen len));
-  effect(TEMP temp);
+  effect(TEMP temp, KILL cr);
   format %{ "vector_mask_gen32 $dst, $len \t! vector mask generator" %}
   ins_encode %{
     __ genmask($dst$$KRegister, $len$$Register, $temp$$Register);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320209](https://bugs.openjdk.org/browse/JDK-8320209) needs maintainer approval

### Issue
 * [JDK-8320209](https://bugs.openjdk.org/browse/JDK-8320209): VectorMaskGen clobbers rflags on x86_64 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/375/head:pull/375` \
`$ git checkout pull/375`

Update a local copy of the PR: \
`$ git checkout pull/375` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 375`

View PR using the GUI difftool: \
`$ git pr show -t 375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/375.diff">https://git.openjdk.org/jdk21u/pull/375.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/375#issuecomment-1815002520)