### PR TITLE
8306561: Possible out of bounds access in print_pointer_information

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -211,7 +211,8 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     const uint8_t* here = align_down(addr, smallest_possible_alignment);
     const uint8_t* const end = here - (0x1000 + sizeof(MallocHeader)); // stop searching after 4k
     for (; here >= end; here -= smallest_possible_alignment) {
-      if (!os::is_readable_pointer(here)) {
+      // JDK-8306561: cast to a MallocHeader needs to guarantee it can reside in readable memory
+      if (!os::is_readable_range(here, here + sizeof(MallocHeader) - 1)) {
         // Probably OOB, give up
         break;
       }

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -212,7 +212,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     const uint8_t* const end = here - (0x1000 + sizeof(MallocHeader)); // stop searching after 4k
     for (; here >= end; here -= smallest_possible_alignment) {
       // JDK-8306561: cast to a MallocHeader needs to guarantee it can reside in readable memory
-      if (!os::is_readable_range(here, here + sizeof(MallocHeader) - 1)) {
+      if (!os::is_readable_range(here, here + sizeof(MallocHeader))) {
         // Probably OOB, give up
         break;
       }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -137,9 +137,6 @@ serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 #############################################################################
 
-gtest/GTestWrapper.java 8306561 aix-ppc64
-gtest/NMTGtests.java#nmt-detail 8306561 aix-ppc64
-gtest/NMTGtests.java#nmt-summary 8306561 aix-ppc64
 
 #############################################################################
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8306561](https://bugs.openjdk.org/browse/JDK-8306561), commit [d6ce62eb](https://github.com/openjdk/jdk/commit/d6ce62ebc01eb483b486af886d9b79f60ff87de1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It also contains a backport of [JDK-8319542](https://bugs.openjdk.org/browse/JDK-8319542) inline.


Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8319542](https://bugs.openjdk.org/browse/JDK-8319542) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306561](https://bugs.openjdk.org/browse/JDK-8306561) needs maintainer approval

### Issues
 * [JDK-8306561](https://bugs.openjdk.org/browse/JDK-8306561): Possible out of bounds access in print_pointer_information (**Bug** - P3 - Approved)
 * [JDK-8319542](https://bugs.openjdk.org/browse/JDK-8319542): Fix boundaries of region to be tested with os::is_readable_range (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/379.diff">https://git.openjdk.org/jdk21u/pull/379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/379#issuecomment-1816621650)