### PR TITLE
8316025: Use testUI() method of PassFailJFrame.Builder in FileChooserSymLinkTest.java

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -22,21 +22,21 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.List;
 
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
-import javax.swing.JTextArea;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
+import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
 /*
@@ -51,87 +51,80 @@ import javax.swing.WindowConstants;
  * @run main/manual FileChooserSymLinkTest
  */
 public class FileChooserSymLinkTest {
+    private static final String INSTRUCTIONS = """
+            <html><body>
+            Instructions to Test:
+            <ol>
+            <li>Open an elevated <i>Command Prompt</i>.
+            <li>Paste the following commands:
+            <pre><code>cd /d C:\\
+            mkdir FileChooserTest
+            cd FileChooserTest
+            mkdir target
+            mklink /d link target</code></pre>
+
+            <li>Navigate to <code>C:\\FileChooserTest</code> in
+                the <code>JFileChooser</code>.
+            <li>Perform testing in single- and multi-selection modes:
+                <ul style="margin-bottom: 0px">
+                <li><strong>Single-selection:</strong>
+                    <ol>
+                    <li>Ensure <b>Enable multi-selection</b> is cleared
+                        (the default state).
+                    <li>Click <code>link</code> directory,
+                        the absolute path of the symbolic
+                        link should be displayed.<br>
+                        If it's <code>null</code>, click <b>Fail</b>.
+                    <li>Click <code>target</code> directory,
+                        its absolute path should be displayed.
+                    </ol>
+                <li><strong>Multi-selection:</strong>
+                    <ol>
+                    <li>Select <b>Enable multi-selection</b>.
+                    <li>Click <code>link</code>,
+                    <li>Press <kbd>Ctrl</kbd> and
+                        then click <code>target</code>.
+                    <li>Both should be selected and
+                        their absolute paths should be displayed.
+                    <li>If <code>link</code> can't be selected or
+                        if its absolute path is <code>null</code>,
+                        click <b>Fail</b>.
+                    </ol>
+                </ul>
+                <p>If <code>link</code> can be selected in both
+                single- and multi-selection modes, click <b>Pass</b>.</p>
+            <li>When done with testing, paste the following commands to
+                remove the <code>FileChooserTest</code> directory:
+            <pre><code>cd \\
+            rmdir /s /q C:\\FileChooserTest</code></pre>
+
+            or use File Explorer to clean it up.
+            </ol>
+            """;
+
     static JFrame frame;
     static JFileChooser jfc;
     static JPanel panel;
     static JTextArea pathList;
     static JCheckBox multiSelection;
-    static PassFailJFrame passFailJFrame;
 
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                try {
-                    initialize();
-                } catch (InterruptedException | InvocationTargetException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-        passFailJFrame.awaitAndCheck();
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(35)
+                      .columns(50)
+                      .testUI(FileChooserSymLinkTest::createTestUI)
+                      .build()
+                      .awaitAndCheck();
     }
 
-    static void initialize() throws InterruptedException, InvocationTargetException {
-        //Initialize the components
-        final String INSTRUCTIONS = """
-                <html><body>
-                Instructions to Test:
-                <ol>
-                <li>Open an elevated <i>Command Prompt</i>.
-                <li>Paste the following commands:
-                <pre><code>cd /d C:\\
-                mkdir FileChooserTest
-                cd FileChooserTest
-                mkdir target
-                mklink /d link target</code></pre>
-
-                <li>Navigate to <code>C:\\FileChooserTest</code> in
-                    the <code>JFileChooser</code>.
-                <li>Perform testing in single- and multi-selection modes:
-                    <ul style="margin-bottom: 0px">
-                    <li><strong>Single-selection:</strong>
-                        <ol>
-                        <li>Ensure <b>Enable multi-selection</b> is cleared
-                            (the default state).
-                        <li>Click <code>link</code> directory,
-                            the absolute path of the symbolic
-                            link should be displayed.<br>
-                            If it's <code>null</code>, click <b>Fail</b>.
-                        <li>Click <code>target</code> directory,
-                            its absolute path should be displayed.
-                        </ol>
-                    <li><strong>Multi-selection:</strong>
-                        <ol>
-                        <li>Select <b>Enable multi-selection</b>.
-                        <li>Click <code>link</code>,
-                        <li>Press <kbd>Ctrl</kbd> and
-                            then click <code>target</code>.
-                        <li>Both should be selected and
-                            their absolute paths should be displayed.
-                        <li>If <code>link</code> can't be selected or
-                            if its absolute path is <code>null</code>,
-                            click <b>Fail</b>.
-                        </ol>
-                    </ul>
-                    <p>If <code>link</code> can be selected in both
-                    single- and multi-selection modes, click <b>Pass</b>.</p>
-                <li>When done with testing, paste the following commands to
-                    remove the <code>FileChooserTest</code> directory:
-                <pre><code>cd \\
-                rmdir /s /q C:\\FileChooserTest</code></pre>
-
-                or use File Explorer to clean it up.
-                </ol>
-                """;
+    private static List<Window> createTestUI() {
         frame = new JFrame("JFileChooser Symbolic Link test");
         panel = new JPanel(new BorderLayout());
         multiSelection = new JCheckBox("Enable Multi-Selection");
         pathList = new JTextArea(10, 50);
         jfc = new JFileChooser(new File("C:\\"));
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 50);
 
-        PassFailJFrame.addTestWindow(frame);
-        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         panel.add(multiSelection, BorderLayout.EAST);
         panel.add(new JScrollPane(pathList), BorderLayout.WEST);
@@ -166,6 +159,6 @@ public class FileChooserSymLinkTest {
         frame.add(panel, BorderLayout.NORTH);
         frame.add(jfc, BorderLayout.CENTER);
         frame.pack();
-        frame.setVisible(true);
+        return List.of(frame);
     }
 }


### PR DESCRIPTION
Backports an example of using `Builder.testUI` method in `PassFailJFrame`.

This is a clean backport. It depends on [JDK-8294156](https://bugs.openjdk.org/browse/JDK-8294156) being already integrated, see #385 as well as [JDK-8316003](https://bugs.openjdk.org/browse/JDK-8316003) in #353.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316025](https://bugs.openjdk.org/browse/JDK-8316025) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316025](https://bugs.openjdk.org/browse/JDK-8316025): Use testUI() method of PassFailJFrame.Builder in FileChooserSymLinkTest.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/386/head:pull/386` \
`$ git checkout pull/386`

Update a local copy of the PR: \
`$ git checkout pull/386` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 386`

View PR using the GUI difftool: \
`$ git pr show -t 386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/386.diff">https://git.openjdk.org/jdk21u/pull/386.diff</a>

</details>
