### PR TITLE
8316415: Parallelize sun/security/rsa/SignedObjectChain.java subtests

### DIFF
--- a/test/jdk/sun/security/rsa/SignedObjectChain.java
+++ b/test/jdk/sun/security/rsa/SignedObjectChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import java.util.Arrays;
+
 /*
  * @test
  * @bug 8050374 8146293
@@ -31,7 +33,6 @@
  * @summary Verify a chain of signed objects
  */
 public class SignedObjectChain {
-
     private static class Test extends Chain.Test {
 
         public Test(Chain.SigAlg sigAlg) {
@@ -52,10 +53,9 @@ public class SignedObjectChain {
     };
 
     public static void main(String argv[]) {
-        boolean resutl = java.util.Arrays.stream(tests).allMatch(
-                (test) -> Chain.runTest(test));
+        boolean result = Arrays.stream(tests).parallel().allMatch(Chain::runTest);
 
-        if(resutl) {
+        if (result) {
             System.out.println("All tests passed");
         } else {
             throw new RuntimeException("Some tests failed");


### PR DESCRIPTION
Clean backport to improve test performance.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, C1, test passes and time improves

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316415](https://bugs.openjdk.org/browse/JDK-8316415) needs maintainer approval

### Issue
 * [JDK-8316415](https://bugs.openjdk.org/browse/JDK-8316415): Parallelize sun/security/rsa/SignedObjectChain.java subtests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/395/head:pull/395` \
`$ git checkout pull/395`

Update a local copy of the PR: \
`$ git checkout pull/395` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 395`

View PR using the GUI difftool: \
`$ git pr show -t 395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/395.diff">https://git.openjdk.org/jdk21u/pull/395.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/395#issuecomment-1822674089)