### PR TITLE
Backport 504b0bdaaa7fb7c822014d8bd2845299fbdaf0e8

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -133,6 +133,21 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DARM=1
   endif
 
+  # Set ASSERT, NDEBUG and PRODUCT flags just like in JvmFlags.gmk
+  ifeq ($(DEBUG_LEVEL), release)
+    # release builds disable uses of assert macro from <assert.h>.
+    ADLCFLAGS += -DNDEBUG
+    # For hotspot, release builds differ internally between "optimized" and "product"
+    # in that "optimize" does not define PRODUCT.
+    ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
+      ADLCFLAGS += -DPRODUCT
+    endif
+  else ifeq ($(DEBUG_LEVEL), fastdebug)
+    ADLCFLAGS += -DASSERT
+  else ifeq ($(DEBUG_LEVEL), slowdebug)
+    ADLCFLAGS += -DASSERT
+  endif
+
   ##############################################################################
   # Concatenate all ad source files into a single file, which will be fed to
   # adlc. Also include a #line directive at the start of every included file


### PR DESCRIPTION
Clean backport to make sure .ad files can use diagnostic asserts.

Additional testing:
 - [ ] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [ ] Linux AArch64 fastdebug `tier1 tier2 tier3`