### PR TITLE
8315692: Parallelize gc/stress/TestStressRSetCoarsening.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -27,13 +27,12 @@ import java.util.concurrent.TimeoutException;
 import jdk.test.whitebox.WhiteBox;
 
 /*
- * @test TestStressRSetCoarsening.java
+ * @test
  * @key stress
  * @bug 8146984 8147087
  * @requires vm.gc.G1
  * @requires os.maxMemory > 3G
  * @requires vm.opt.MaxGCPauseMillis == "null"
- *
  * @summary Stress G1 Remembered Set by creating a lot of cross region links
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -42,27 +41,82 @@ import jdk.test.whitebox.WhiteBox;
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  1  0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 1 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening  1 10 300
+ *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening 1 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=32m gc.stress.TestStressRSetCoarsening 42 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  2 0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 2 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0  1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0 1800
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10  10 1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10 10 1800
  */
 
 /**
@@ -95,7 +149,7 @@ public class TestStressRSetCoarsening {
         }
         int objectsPerRegion = Integer.parseInt(args[0]); // 1 means humongous
         int regsToRefresh = Integer.parseInt(args[1]);  // 0 means no regions to refresh at the end of cycle
-        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working eariler
+        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working earlier
         new TestStressRSetCoarsening(objectsPerRegion, regsToRefresh, timeout).go();
     }
 


### PR DESCRIPTION
The commit includes backporting a564d436c722f14041231158f21c4ad3a2f6a3a5 from upstream tp jdk21u. The hunks were applied cleanly. Below are the results upon running in AL2_x86_64:
* after_release: 1573.15s user 63.94s system 270% cpu 10:05.94 total
* after_fastdebug: 8382.45s user 747.00s system 493% cpu 30:51.02 total
* before_release: 1514.58s user 69.27s system 109% cpu 24:10.98 total
* before_fastdebug: 2934.79s user 66.46s system 112% cpu 44:16.28 total

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692): Parallelize gc/stress/TestStressRSetCoarsening.java test (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/397.diff">https://git.openjdk.org/jdk21u/pull/397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/397#issuecomment-1822798464)