### PR TITLE
8319137: release _object in ObjectMonitor dtor to avoid races

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -276,24 +276,15 @@ ObjectMonitor::ObjectMonitor(oop object) :
 { }
 
 ObjectMonitor::~ObjectMonitor() {
-  if (!_object.is_null()) {
-    // Release object's oop storage if it hasn't already been done.
-    release_object();
-  }
+  _object.release(_oop_storage);
 }
 
 oop ObjectMonitor::object() const {
   check_object_context();
-  if (_object.is_null()) {
-    return nullptr;
-  }
   return _object.resolve();
 }
 
 oop ObjectMonitor::object_peek() const {
-  if (_object.is_null()) {
-    return nullptr;
-  }
   return _object.peek();
 }
 
@@ -597,9 +588,6 @@ bool ObjectMonitor::deflate_monitor() {
     // Install the old mark word if nobody else has already done it.
     install_displaced_markword_in_object(obj);
   }
-
-  // Release object's oop storage since the ObjectMonitor has been deflated:
-  release_object();
 
   // We leave owner == DEFLATER_MARKER and contentions < 0
   // to force any racing threads to retry.

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -363,7 +363,6 @@ private:
   // Deflation support
   bool      deflate_monitor();
   void      install_displaced_markword_in_object(const oop obj);
-  void      release_object() { _object.release(_oop_storage); _object.set_null(); }
 };
 
 #endif // SHARE_RUNTIME_OBJECTMONITOR_HPP

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1646,14 +1646,18 @@ public:
   };
 };
 
-static size_t delete_monitors(GrowableArray<ObjectMonitor*>* delete_list) {
+static size_t delete_monitors(JavaThread* current, GrowableArray<ObjectMonitor*>* delete_list,
+                              LogStream* ls, elapsedTimer* timer_p) {
   NativeHeapTrimmer::SuspendMark sm("monitor deletion");
-  size_t count = 0;
+  size_t deleted_count = 0;
   for (ObjectMonitor* monitor: *delete_list) {
     delete monitor;
-    count++;
+    deleted_count++;
+    // A JavaThread must check for a safepoint/handshake and honor it.
+    ObjectSynchronizer::chk_for_block_req(current, "deletion", "deleted_count",
+                                          deleted_count, ls, timer_p);
   }
-  return count;
+  return deleted_count;
 }
 
 // This function is called by the MonitorDeflationThread to deflate
@@ -1731,30 +1735,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
     // After the handshake, safely free the ObjectMonitors that were
     // deflated and unlinked in this cycle.
-    if (current->is_Java_thread()) {
-      if (ls != NULL) {
-        timer.stop();
-        ls->print_cr("before setting blocked: unlinked_count=" SIZE_FORMAT
-                     ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
-                     SIZE_FORMAT ", max=" SIZE_FORMAT,
-                     unlinked_count, in_use_list_ceiling(),
-                     _in_use_list.count(), _in_use_list.max());
-      }
-      // Mark the calling JavaThread blocked (safepoint safe) while we free
-      // the ObjectMonitors so we don't delay safepoints whilst doing that.
-      ThreadBlockInVM tbivm(JavaThread::cast(current));
-      if (ls != NULL) {
-        ls->print_cr("after setting blocked: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
-                     in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
-        timer.start();
-      }
-      deleted_count = delete_monitors(&delete_list);
-      // ThreadBlockInVM is destroyed here
-    } else {
-      // A non-JavaThread can just free the ObjectMonitors:
-      deleted_count = delete_monitors(&delete_list);
-    }
+    deleted_count = delete_monitors(JavaThread::cast(current), &delete_list, ls, &timer);
     assert(unlinked_count == deleted_count, "must be");
   }
 


### PR DESCRIPTION
This effectively reverts [JDK-8256302](https://bugs.openjdk.org/browse/JDK-8256302), which introduced race condition in JDK 21. The patch does not apply cleanly for two reasons:
 1. Deleted `release_object()` has a different form in JDK 21 due to slight WeakHandle API change. This is not relevant for this patch, just a backporting conflict. I removed `release_object()` by hand.
 2. Without [JDK-8319896](https://bugs.openjdk.org/browse/JDK-8319896) we cannot do `JavaThread::cast` in the incoming changeset, because we can be called by a non-Java thread. I suspect JDK-8319896 would come with its own bugtail, so I would prefer not to backport it now. I have replaced the code back to original pre- JDK 21 form in a separate commit: [Modifications to fit JDK 21](https://github.com/openjdk/jdk21u/commit/17477d8fca6f4e8f9c8ae2732cfb42f0ce887897)

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `runtime/Monitor` passes
 - [x] Linux AArch64 server fastdebug, `tier1 tier2 tier3 tier4`
 - [x] Linux x86_64 server fastdebug, `tier1 tier2 tier3 tier4`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8319137](https://bugs.openjdk.org/browse/JDK-8319137) needs maintainer approval

### Issue
 * [JDK-8319137](https://bugs.openjdk.org/browse/JDK-8319137): release _object in ObjectMonitor dtor to avoid races (**Bug** - P2 - Requested)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/401/head:pull/401` \
`$ git checkout pull/401`

Update a local copy of the PR: \
`$ git checkout pull/401` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 401`

View PR using the GUI difftool: \
`$ git pr show -t 401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/401.diff">https://git.openjdk.org/jdk21u/pull/401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/401#issuecomment-1826028379)