### PR TITLE
Backport bd918f49d29bcbc699e07b4ef8d23cfe1abd32df

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -238,7 +238,11 @@ public class Threads {
                         return thread;
                      }
                 }
-                throw new InternalError("We should have found a thread that owns the anonymous lock");
+                // We should have found the owner, however, as the VM could be in any state, including the middle
+                // of performing GC, it is not always possible to do so. Just return null if we can't locate it.
+                System.out.println("Warning: We failed to find a thread that owns an anonymous lock. This is likely");
+                System.out.println("due to the JVM currently running a GC. Locking information may not be accurate.");
+                return null;
             }
             // Owner can only be threads at this point.
             Address o = monitor.owner();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bd918f49](https://github.com/openjdk/jdk/commit/bd918f49d29bcbc699e07b4ef8d23cfe1abd32df) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Roman Kennke on 29 Sep 2023 and was reviewed by Chris Plummer and David Holmes.

The fix relaxes an exception in the SA related to lightweight locking to print a warning instead. The fix is in mainline since end of september and has not accrued a bug-tail. Lightweight locking has been implemented in JDK21 but is not enabled by default.

Thanks!