### PR TITLE
8320564: RISC-V: Minimal build failed after JDK-8316592

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2049,23 +2049,6 @@ void MacroAssembler::cmp_klass(Register oop, Register trial_klass, Register tmp1
   beq(trial_klass, tmp1, L);
 }
 
-// Multiply and multiply-accumulate unsigned 64-bit registers.
-void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
-  assert_different_registers(prod_lo, prod_hi);
-
-  mul(prod_lo, n, m);
-  mulhu(prod_hi, n, m);
-}
-void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
-                Register m, Register tmp1, Register tmp2) {
-  assert_different_registers(sum_lo, sum_hi);
-  assert_different_registers(sum_hi, tmp2);
-
-  wide_mul(tmp1, tmp2, n, m);
-  cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
-  adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
-}
-
 // Move an oop into a register.
 void MacroAssembler::movoop(Register dst, jobject obj) {
   int oop_index;
@@ -3555,6 +3538,24 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   j(L_tail_loop);
 
   bind(L_end);
+}
+
+// Multiply and multiply-accumulate unsigned 64-bit registers.
+void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
+  assert_different_registers(prod_lo, prod_hi);
+
+  mul(prod_lo, n, m);
+  mulhu(prod_hi, n, m);
+}
+
+void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
+                               Register m, Register tmp1, Register tmp2) {
+  assert_different_registers(sum_lo, sum_hi);
+  assert_different_registers(sum_hi, tmp2);
+
+  wide_mul(tmp1, tmp2, n, m);
+  cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
+  adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
 }
 
 // add two unsigned input and output carry

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -198,10 +198,6 @@ class MacroAssembler: public Assembler {
   void store_klass(Register dst, Register src, Register tmp = t0);
   void cmp_klass(Register oop, Register trial_klass, Register tmp1, Register tmp2, Label &L);
 
-  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
-  void wide_madd(Register sum_lo, Register sum_hi, Register n,
-                Register m, Register tmp1, Register tmp2);
-
   void encode_klass_not_null(Register r, Register tmp = t0);
   void decode_klass_not_null(Register r, Register tmp = t0);
   void encode_klass_not_null(Register dst, Register src, Register tmp);
@@ -1188,6 +1184,9 @@ public:
 #ifdef COMPILER2
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k, Register tmp);
+  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
+  void wide_madd(Register sum_lo, Register sum_hi, Register n,
+                 Register m, Register tmp1, Register tmp2);
   void cad(Register dst, Register src1, Register src2, Register carry);
   void cadc(Register dst, Register src1, Register src2, Register carry);
   void adc(Register dst, Register src1, Register src2, Register carry);


### PR DESCRIPTION
Fix for initial implementation of `_poly1305_processBlocks`. JBS issue: https://bugs.openjdk.org/browse/JDK-8320564

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320564](https://bugs.openjdk.org/browse/JDK-8320564) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #390 must be integrated first

### Issue
 * [JDK-8320564](https://bugs.openjdk.org/browse/JDK-8320564): RISC-V: Minimal build failed after JDK-8316592 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/404/head:pull/404` \
`$ git checkout pull/404`

Update a local copy of the PR: \
`$ git checkout pull/404` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 404`

View PR using the GUI difftool: \
`$ git pr show -t 404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/404.diff">https://git.openjdk.org/jdk21u/pull/404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/404#issuecomment-1826305298)