### PR TITLE
8319633: runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX

### DIFF
--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -44,8 +44,17 @@ public class TestPosixSig {
         if (args.length == 0) {
 
             // Create a new java process for the TestPsig Java/JNI test.
+            // We run the VM in interpreted mode, because the JIT might mark
+            // a Java method as not-entrant, which means turning the first instruction
+            // into an illegal one. Calling such a method after establishing
+            // the new SIGILL signal handler with TestPosixSig.changeSigActionFor(4)
+            // below, but before the JNI checker noted and reacted on this signal handler
+            // modification, the JVM may crash or hang in an endless loop, where the
+            // illegal instruction will be continously executed, raising SIGILL, and
+            // the signal handler will return to the illegal instruction again...
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:+CheckJNICalls",
+                "-Xint",
                 "-Djava.library.path=" + libpath + ":.",
                 "TestPosixSig", "dummy");
 


### PR DESCRIPTION
We should not mix os::dll_load() with dlclose(), but should call os::dll_unload(). At the moment this is benign, but this prevents certain type of platforms specific workarounds inside os::dll_load() and is a prerequisite for these upcoming changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8319633](https://bugs.openjdk.org/browse/JDK-8319633) needs maintainer approval

### Issue
 * [JDK-8319633](https://bugs.openjdk.org/browse/JDK-8319633): runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/407/head:pull/407` \
`$ git checkout pull/407`

Update a local copy of the PR: \
`$ git checkout pull/407` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 407`

View PR using the GUI difftool: \
`$ git pr show -t 407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/407.diff">https://git.openjdk.org/jdk21u/pull/407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/407#issuecomment-1829844670)