### PR TITLE
8313082: Enable CreateCoredumpOnCrash for testing in makefiles

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -801,8 +801,10 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -e:JIB_DATA_DIR
   # If running on Windows, propagate the _NT_SYMBOL_PATH to enable
   # symbol lookup in hserr files
+  # The minidumps are disabled by default on client Windows, so enable them
   ifeq ($$(call isTargetOs, windows), true)
     $1_JTREG_BASIC_OPTIONS += -e:_NT_SYMBOL_PATH
+    $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:+CreateCoredumpOnCrash
   else ifeq ($$(call isTargetOs, linux), true)
       $1_JTREG_BASIC_OPTIONS += -e:_JVM_DWARF_PATH=$$(SYMBOLS_IMAGE_DIR)
   endif


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8313082](https://bugs.openjdk.org/browse/JDK-8313082) needs maintainer approval

### Issue
 * [JDK-8313082](https://bugs.openjdk.org/browse/JDK-8313082): Enable CreateCoredumpOnCrash for testing in makefiles (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/409/head:pull/409` \
`$ git checkout pull/409`

Update a local copy of the PR: \
`$ git checkout pull/409` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 409`

View PR using the GUI difftool: \
`$ git pr show -t 409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/409.diff">https://git.openjdk.org/jdk21u/pull/409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/409#issuecomment-1831862694)