### PR TITLE
8314220: Configurable InlineCacheBuffer size

### DIFF
--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -140,7 +140,7 @@ void ICStub::print() {
 
 void InlineCacheBuffer::initialize() {
   if (_buffer != nullptr) return; // already initialized
-  _buffer = new StubQueue(new ICStubInterface, 10*K, InlineCacheBuffer_lock, "InlineCacheBuffer");
+  _buffer = new StubQueue(new ICStubInterface, checked_cast<int>(InlineCacheBufferSize), InlineCacheBuffer_lock, "InlineCacheBuffer");
   assert (_buffer != nullptr, "cannot allocate InlineCacheBuffer");
 }
 

--- a/src/hotspot/share/code/stubs.cpp
+++ b/src/hotspot/share/code/stubs.cpp
@@ -217,8 +217,6 @@ void StubQueue::verify() {
   guarantee(0 <= _queue_begin  && _queue_begin  <  _buffer_limit, "_queue_begin out of bounds");
   guarantee(0 <= _queue_end    && _queue_end    <= _buffer_limit, "_queue_end   out of bounds");
   // verify alignment
-  guarantee(_buffer_size  % stub_alignment() == 0, "_buffer_size  not aligned");
-  guarantee(_buffer_limit % stub_alignment() == 0, "_buffer_limit not aligned");
   guarantee(_queue_begin  % stub_alignment() == 0, "_queue_begin  not aligned");
   guarantee(_queue_end    % stub_alignment() == 0, "_queue_end    not aligned");
   // verify buffer limit/size relationship

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -497,6 +497,11 @@ bool CompilerConfig::check_args_consistency(bool status) {
                 "Invalid NonNMethodCodeHeapSize=%dK. Must be at least %uK.\n", NonNMethodCodeHeapSize/K,
                 min_code_cache_size/K);
     status = false;
+  } else if (InlineCacheBufferSize > NonNMethodCodeHeapSize / 2) {
+    jio_fprintf(defaultStream::error_stream(),
+                "Invalid InlineCacheBufferSize=" SIZE_FORMAT "K. Must be less than or equal to " SIZE_FORMAT "K.\n",
+                InlineCacheBufferSize/K, NonNMethodCodeHeapSize/2/K);
+    status = false;
   }
 
 #ifdef _LP64

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -295,6 +295,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseInlineCaches, true,                                      \
           "Use Inline Caches for virtual calls ")                           \
                                                                             \
+  product(size_t, InlineCacheBufferSize, 10*K, EXPERIMENTAL,                \
+          "InlineCacheBuffer size")                                         \
+                                                                            \
   product(bool, InlineArrayCopy, true, DIAGNOSTIC,                          \
           "Inline arraycopy native that is known to be part of "            \
           "base library DLL")                                               \


### PR DESCRIPTION
Clean backport to allow tuning ICBuffer size, important to dodge many ICBufferFull safepoints.

Additional testing:
 - [x] Eyeballing `-XX:+TraceICBuffer` output on ad-hoc workloads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220) needs maintainer approval

### Issue
 * [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220): Configurable InlineCacheBuffer size (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/419/head:pull/419` \
`$ git checkout pull/419`

Update a local copy of the PR: \
`$ git checkout pull/419` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 419`

View PR using the GUI difftool: \
`$ git pr show -t 419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/419.diff">https://git.openjdk.org/jdk21u/pull/419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/419#issuecomment-1841322333)