### PR TITLE
8318689: jtreg is confused when folder name is the same as the test name

### DIFF
--- a/test/jdk/javax/security/auth/Subject/DoAsTest.java
+++ b/test/jdk/javax/security/auth/Subject/DoAsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.security.auth.Subject;
 
-public class DoAs {
+public class DoAsTest {
 
     public static void main(String[] args) throws Exception {
         final Set<String> outer = new HashSet<>(Arrays.asList("Outer"));


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a9b31b58](https://github.com/openjdk/jdk/commit/a9b31b587c7487b2222773debde1ce2227884959) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Weijun Wang on 26 Oct 2023 and was reviewed by Sean Mullan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8318689](https://bugs.openjdk.org/browse/JDK-8318689) needs maintainer approval

### Issue
 * [JDK-8318689](https://bugs.openjdk.org/browse/JDK-8318689): jtreg is confused when folder name is the same as the test name (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/424.diff">https://git.openjdk.org/jdk21u/pull/424.diff</a>

</details>
