### PR TITLE
8322512: StringBuffer.repeat does not work correctly after toString() was called

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -715,6 +715,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
      */
     @Override
     public synchronized StringBuffer repeat(int codePoint, int count) {
+        toStringCache = null;
         super.repeat(codePoint, count);
         return this;
     }
@@ -726,6 +727,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
      */
     @Override
     public synchronized StringBuffer repeat(CharSequence cs, int count) {
+        toStringCache = null;
         super.repeat(cs, count);
         return this;
     }

--- a/test/jdk/java/lang/StringBuilder/StringBufferRepeat.java
+++ b/test/jdk/java/lang/StringBuilder/StringBufferRepeat.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 
 /**
  * @test
- * @bug 8302323
+ * @bug 8302323 8322512
  * @summary Test StringBuffer.repeat sanity tests
  * @run testng/othervm -XX:-CompactStrings StringBufferRepeat
  * @run testng/othervm -XX:+CompactStrings StringBufferRepeat
@@ -128,6 +128,19 @@ public class StringBufferRepeat {
 
         expected = "\u0000\u0000\u0000\u0000\u0000\u0000\u0020\u0020\u0020\u0020\u0020\u0020\u2461\u2462\u2462\u2462\u2462\u2462\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff";
         assertEquals(expected, sb.toString());
+
+        // toStringCache
+
+        sb.setLength(0);
+        sb.toString();
+        sb.repeat('*', 5);
+        expected = "*****";
+        assertEquals(sb.toString(), expected);
+        sb.setLength(0);
+        sb.toString();
+        sb.repeat("*", 5);
+        assertEquals(sb.toString(), expected);
+
 
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8322512](https://bugs.openjdk.org/browse/JDK-8322512) needs maintainer approval

### Issue
 * [JDK-8322512](https://bugs.openjdk.org/browse/JDK-8322512): StringBuffer.repeat does not work correctly after toString() was called (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/428/head:pull/428` \
`$ git checkout pull/428`

Update a local copy of the PR: \
`$ git checkout pull/428` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 428`

View PR using the GUI difftool: \
`$ git pr show -t 428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/428.diff">https://git.openjdk.org/jdk21u/pull/428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/428#issuecomment-1877073831)