### PR TITLE
8009550: PlatformPCSC should load versioned so

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -81,6 +81,7 @@ public class Debug {
         System.err.println("logincontext  login context results");
         System.err.println("jca           JCA engine class debugging");
         System.err.println("keystore      KeyStore debugging");
+        System.err.println("pcsc          Smartcard library debugging");
         System.err.println("policy        loading and granting");
         System.err.println("provider      security provider debugging");
         System.err.println("pkcs11        PKCS11 session manager debugging");

--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +47,14 @@ class PlatformPCSC {
 
     private static final String PROP_NAME = "sun.security.smartcardio.library";
 
-    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so";
-    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
+    // The architecture templates are for Debian-based systems: https://wiki.debian.org/Multiarch/Tuples
+    // 32-bit arm differs from the pattern of the rest and has to be specified explicitly
+    private static final String[] LIB_TEMPLATES = { "/usr/$LIBISA/libpcsclite.so",
+                                                    "/usr/local/$LIBISA/libpcsclite.so",
+                                                    "/usr/lib/$ARCH-linux-gnu/libpcsclite.so",
+                                                    "/usr/lib/arm-linux-gnueabi/libpcsclite.so",
+                                                    "/usr/lib/arm-linux-gnueabihf/libpcsclite.so" };
+    private static final String[] LIB_SUFFIXES = { ".1", ".0", "" };
     private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
 
     PlatformPCSC() {
@@ -73,23 +80,38 @@ class PlatformPCSC {
     });
 
     // expand $LIBISA to the system specific directory name for libraries
+    // expand $ARCH to the Debian system architecture in use
     private static String expand(String lib) {
         int k = lib.indexOf("$LIBISA");
-        if (k == -1) {
-            return lib;
+        if (k != -1) {
+            String libDir;
+            if ("64".equals(System.getProperty("sun.arch.data.model"))) {
+                // assume Linux convention
+                libDir = "lib64";
+            } else {
+                // must be 32-bit
+                libDir = "lib";
+            }
+            lib = lib.replace("$LIBISA", libDir);
         }
-        String s1 = lib.substring(0, k);
-        String s2 = lib.substring(k + 7);
-        String libDir;
-        if ("64".equals(System.getProperty("sun.arch.data.model"))) {
-            // assume Linux convention
-            libDir = "lib64";
-        } else {
-            // must be 32-bit
-            libDir = "lib";
+
+        k = lib.indexOf("$ARCH");
+        if (k != -1) {
+            String arch = System.getProperty("os.arch");
+            lib = lib.replace("$ARCH", getDebianArchitecture(arch));
         }
-        String s = s1 + libDir + s2;
-        return s;
+
+        return lib;
+    }
+
+    private static String getDebianArchitecture(String jdkArch) {
+        return switch (jdkArch) {
+            case "amd64" -> "x86_64";
+            case "ppc" -> "powerpc";
+            case "ppc64" -> "powerpc64";
+            case "ppc64le" -> "powerpc64le";
+            default -> jdkArch;
+        };
     }
 
     private static String getLibraryName() throws IOException {
@@ -98,15 +120,18 @@ class PlatformPCSC {
         if (lib.length() != 0) {
             return lib;
         }
-        lib = expand(LIB1);
-        if (new File(lib).isFile()) {
-            // if LIB1 exists, use that
-            return lib;
-        }
-        lib = expand(LIB2);
-        if (new File(lib).isFile()) {
-            // if LIB2 exists, use that
-            return lib;
+
+        for (String template : LIB_TEMPLATES) {
+            for (String suffix : LIB_SUFFIXES) {
+                lib = expand(template) + suffix;
+                if (debug != null) {
+                    debug.println("Looking for " + lib);
+                }
+                if (new File(lib).isFile()) {
+                    // if library exists, use that
+                    return lib;
+                }
+            }
         }
 
         // As of macos 11, framework libraries have been removed from the file


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [328b3810](https://github.com/openjdk/jdk/commit/328b381075ab81fd3f899e49e4d71ef19ea28862) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.  It applies cleanly to 21u-dev and builds fine without modification.

The commit being backported was authored by myself on 31 Oct 2023 and was reviewed by Valerie Peng and Thomas Stuefe. It allows the PCSC library to pick up a wider range of libpcsclite libraries without the user having to explicitly specify the library on the command-line. Notably, it solves an issue on RHEL where having the `pcsc-lite-libs` package installed is not sufficient for it to be used by OpenJDK, as it intentionally only provides `/usr/lib64/libpcsclite.so.1` not `/usr/lib64/libpcsclite.so`.

We have been applying a simpler version of this patch to RHEL packages for the last decade without issue. In the majority of cases, it will make the smartcard library work where it hasn't by default before, as a larger range of filenames is now checked.

The only potential compatibility risk I can see is that a system with both `libpcsclite.so.2` and `libpcsclite.so.1`, where `libpcsclite.so` links to `libpcsclite.so.2`. Unpatched, this would load `libpcsclite.so.2` while it would load `libpcsclite.so.1` when patched. This behaviour is actually preferable, as the OpenJDK code is designed around the `.1` API (and even `.0` on Solaris) and the situation very unlikely, given even the new libpcsclite 2.0 library still uses `libpcsclite.so.1`. 

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8009550](https://bugs.openjdk.org/browse/JDK-8009550) needs maintainer approval

### Issue
 * [JDK-8009550](https://bugs.openjdk.org/browse/JDK-8009550): PlatformPCSC should load versioned so (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/438/head:pull/438` \
`$ git checkout pull/438`

Update a local copy of the PR: \
`$ git checkout pull/438` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 438`

View PR using the GUI difftool: \
`$ git pr show -t 438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/438.diff">https://git.openjdk.org/jdk21u/pull/438.diff</a>

</details>
