### PR TITLE
8309890: TestStringDeduplicationInterned.java waits for the wrong condition

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -399,10 +399,8 @@ class TestStringDeduplicationTools {
 
             forceDeduplication(ageThreshold, FullGC);
 
-            if (!waitForDeduplication(dupString3, baseString)) {
-                if (getValue(dupString3) != getValue(internedString)) {
-                    throw new RuntimeException("String 3 doesn't match either");
-                }
+            if (!waitForDeduplication(dupString3, internedString)) {
+                throw new RuntimeException("Deduplication has not occurred for string 3");
             }
 
             if (afterInternedValue != getValue(dupString2)) {


### PR DESCRIPTION
Clean backport to pass the correct string so that `waitForDeduplication` does not always wait for 10 seconds before proceeding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8309890](https://bugs.openjdk.org/browse/JDK-8309890) needs maintainer approval

### Issue
 * [JDK-8309890](https://bugs.openjdk.org/browse/JDK-8309890): TestStringDeduplicationInterned.java waits for the wrong condition (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/445/head:pull/445` \
`$ git checkout pull/445`

Update a local copy of the PR: \
`$ git checkout pull/445` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 445`

View PR using the GUI difftool: \
`$ git pr show -t 445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/445.diff">https://git.openjdk.org/jdk21u/pull/445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/445#issuecomment-2079165533)