### PR TITLE
8338139: {ClassLoading,Memory}MXBean::isVerbose methods are inconsistent with their setVerbose methods

### DIFF
--- a/src/hotspot/share/services/classLoadingService.cpp
+++ b/src/hotspot/share/services/classLoadingService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,22 @@ bool ClassLoadingService::set_verbose(bool verbose) {
   LogConfiguration::configure_stdout(level, false, LOG_TAGS(class, load));
   reset_trace_class_unloading();
   return verbose;
+}
+
+bool ClassLoadingService::get_verbose() {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
+    // set_verbose looks for a non-exact match for class+load,
+    // so look for all tag sets that match class+load*
+    if (ts->contains(LogTag::_class) &&
+        ts->contains(LogTag::_load)) {
+      LogLevelType l = ts->level_for(LogConfiguration::StdoutLog);
+      if (l != LogLevel::Info && l != LogLevel::Debug && l != LogLevel::Trace) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 // Caller to this function must own Management_lock

--- a/src/hotspot/share/services/classLoadingService.cpp
+++ b/src/hotspot/share/services/classLoadingService.cpp
@@ -36,6 +36,7 @@
 #include "utilities/defaultStream.hpp"
 #include "logging/log.hpp"
 #include "logging/logConfiguration.hpp"
+#include "logging/logFileStreamOutput.hpp"
 
 #ifdef DTRACE_ENABLED
 
@@ -134,7 +135,7 @@ bool ClassLoadingService::get_verbose() {
     // so look for all tag sets that match class+load*
     if (ts->contains(LogTag::_class) &&
         ts->contains(LogTag::_load)) {
-      LogLevelType l = ts->level_for(LogConfiguration::StdoutLog);
+      LogLevelType l = ts->level_for(StdoutLog);
       if (l != LogLevel::Info && l != LogLevel::Debug && l != LogLevel::Trace) {
         return false;
       }

--- a/src/hotspot/share/services/classLoadingService.hpp
+++ b/src/hotspot/share/services/classLoadingService.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ class ClassLoadingService : public AllStatic {
  public:
   static void init() NOT_MANAGEMENT_RETURN;
   static bool set_verbose(bool verbose) NOT_MANAGEMENT_RETURN_(false);
+  static bool get_verbose() NOT_MANAGEMENT_RETURN_(false);
   static void reset_trace_class_unloading() NOT_MANAGEMENT_RETURN;
   static jlong loaded_class_count() NOT_MANAGEMENT_RETURN_(0L);
   static jlong unloaded_class_count() NOT_MANAGEMENT_RETURN_(0L);
@@ -63,7 +64,6 @@ class ClassLoadingService : public AllStatic {
   static jlong loaded_shared_class_bytes() NOT_MANAGEMENT_RETURN_(0L);
   static jlong unloaded_shared_class_bytes() NOT_MANAGEMENT_RETURN_(0L);
   static jlong class_method_data_size() NOT_MANAGEMENT_RETURN_(0L);
-  static bool get_verbose() { return log_is_enabled(Info, class, load); }
 
   static void notify_class_loaded(InstanceKlass* k, bool shared_class)
       NOT_MANAGEMENT_RETURN;

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,21 @@ bool MemoryService::set_verbose(bool verbose) {
   ClassLoadingService::reset_trace_class_unloading();
 
   return verbose;
+}
+
+bool MemoryService::get_verbose() {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
+    // set_verbose only sets gc and not gc*, so check for an exact match
+    const bool is_gc_exact_match = ts->contains(LogTag::_gc) && ts->ntags() == 1;
+    if (is_gc_exact_match) {
+      LogLevelType l = ts->level_for(LogConfiguration::StdoutLog);
+      if (l == LogLevel::Info || l == LogLevel::Debug || l == LogLevel::Trace) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 Handle MemoryService::create_MemoryUsage_obj(MemoryUsage usage, TRAPS) {

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -26,6 +26,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "logging/logConfiguration.hpp"
+#include "logging/logFileStreamOutput.hpp"
 #include "memory/heap.hpp"
 #include "memory/memRegion.hpp"
 #include "memory/resourceArea.hpp"
@@ -207,7 +208,7 @@ bool MemoryService::get_verbose() {
     // set_verbose only sets gc and not gc*, so check for an exact match
     const bool is_gc_exact_match = ts->contains(LogTag::_gc) && ts->ntags() == 1;
     if (is_gc_exact_match) {
-      LogLevelType l = ts->level_for(LogConfiguration::StdoutLog);
+      LogLevelType l = ts->level_for(StdoutLog);
       if (l == LogLevel::Info || l == LogLevel::Debug || l == LogLevel::Trace) {
         return true;
       }

--- a/src/hotspot/share/services/memoryService.hpp
+++ b/src/hotspot/share/services/memoryService.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,8 +106,8 @@ public:
                      GCCause::Cause cause,
                      bool allMemoryPoolsAffected, const char* notificationMessage = nullptr);
 
-  static bool get_verbose() { return log_is_enabled(Info, gc); }
   static bool set_verbose(bool verbose);
+  static bool get_verbose();
 
   // Create an instance of java/lang/management/MemoryUsage
   static Handle create_MemoryUsage_obj(MemoryUsage usage, TRAPS);

--- a/test/jdk/java/lang/management/ClassLoadingMXBean/TestVerboseClassLoading.java
+++ b/test/jdk/java/lang/management/ClassLoadingMXBean/TestVerboseClassLoading.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8338139
+ * @summary Basic unit test of ClassLoadingMXBean.set/isVerbose() when
+ *          related unified logging is enabled.
+ *
+ * @run main/othervm -Xlog:class+load=trace:file=vm.log TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=debug:file=vm.log TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=info:file=vm.log TestVerboseClassLoading false
+ *
+ * @run main/othervm -Xlog:class+load=trace TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=debug TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=info TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=warning TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=error TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load=off TestVerboseClassLoading false
+ *
+ * @run main/othervm -Xlog:class+load*=trace TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=debug TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=warning TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=error TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=off TestVerboseClassLoading false
+ *
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=trace TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=debug TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=info TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=warning TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=error TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=info,class+load+cause=off TestVerboseClassLoading false
+ *
+ * @run main/othervm -Xlog:all=trace:file=vm.log TestVerboseClassLoading false
+ */
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ClassLoadingMXBean;
+
+public class TestVerboseClassLoading {
+
+    public static void main(String[] args) throws Exception {
+        ClassLoadingMXBean mxBean = ManagementFactory.getClassLoadingMXBean();
+        boolean expected = Boolean.parseBoolean(args[0]);
+        boolean initial = mxBean.isVerbose();
+        if (expected != initial) {
+            throw new Error("Initial verbosity setting was unexpectedly " + initial);
+        }
+        mxBean.setVerbose(false);
+        if (mxBean.isVerbose()) {
+            throw new Error("Verbosity was still enabled");
+        }
+        mxBean.setVerbose(true);
+        if (!mxBean.isVerbose()) {
+            throw new Error("Verbosity was still disabled");
+        }
+        // Turn off again as a double-check and also to avoid excessive logging
+        mxBean.setVerbose(false);
+        if (mxBean.isVerbose()) {
+            throw new Error("Verbosity was still enabled");
+        }
+    }
+}

--- a/test/jdk/java/lang/management/ClassLoadingMXBean/TestVerboseClassLoading.java
+++ b/test/jdk/java/lang/management/ClassLoadingMXBean/TestVerboseClassLoading.java
@@ -45,12 +45,12 @@
  * @run main/othervm -Xlog:class+load*=error TestVerboseClassLoading false
  * @run main/othervm -Xlog:class+load*=off TestVerboseClassLoading false
  *
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=trace TestVerboseClassLoading true
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=debug TestVerboseClassLoading true
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=info TestVerboseClassLoading true
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=warning TestVerboseClassLoading false
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=error TestVerboseClassLoading false
- * @run main/othervm -Xlog:class+load*=info,class+load+cause=off TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=info,class+load=trace TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load=debug TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load=info TestVerboseClassLoading true
+ * @run main/othervm -Xlog:class+load*=info,class+load=warning TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=info,class+load=error TestVerboseClassLoading false
+ * @run main/othervm -Xlog:class+load*=info,class+load=off TestVerboseClassLoading false
  *
  * @run main/othervm -Xlog:all=trace:file=vm.log TestVerboseClassLoading false
  */

--- a/test/jdk/java/lang/management/MemoryMXBean/TestVerboseMemory.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/TestVerboseMemory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8338139
+ * @summary Basic unit test of TestVerboseMemory.set/isVerbose() when
+ *          related unified logging is enabled.
+ *
+ * @run main/othervm -Xlog:gc=trace:file=vm.log TestVerboseMemory false
+ * @run main/othervm -Xlog:gc=debug:file=vm.log TestVerboseMemory false
+ * @run main/othervm -Xlog:gc=info:file=vm.log TestVerboseMemory false
+ *
+ * @run main/othervm -Xlog:gc=off TestVerboseMemory false
+ * @run main/othervm -Xlog:gc=error TestVerboseMemory false
+ * @run main/othervm -Xlog:gc=warning TestVerboseMemory false
+ *
+ * @run main/othervm -Xlog:gc=info TestVerboseMemory true
+ * @run main/othervm -Xlog:gc=trace TestVerboseMemory true
+ * @run main/othervm -Xlog:gc=debug TestVerboseMemory true
+ *
+ * @run main/othervm -Xlog:gc*=info TestVerboseMemory true
+ * @run main/othervm -Xlog:gc*=debug TestVerboseMemory true
+ * @run main/othervm -Xlog:gc*=trace TestVerboseMemory true
+ *
+ * @run main/othervm -Xlog:gc=info,gc+init=off TestVerboseMemory true
+ * @run main/othervm -Xlog:gc=off,gc+init=info TestVerboseMemory false
+ * @run main/othervm -Xlog:gc,gc+init TestVerboseMemory true
+ *
+ * @run main/othervm -Xlog:all=trace:file=vm.log TestVerboseMemory false
+ */
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+public class TestVerboseMemory {
+
+    public static void main(String[] args) throws Exception {
+        MemoryMXBean mxBean = ManagementFactory.getMemoryMXBean();
+        boolean expected = Boolean.parseBoolean(args[0]);
+        boolean initial = mxBean.isVerbose();
+        if (expected != initial) {
+            throw new Error("Initial verbosity setting was unexpectedly " + initial);
+        }
+        mxBean.setVerbose(false);
+        if (mxBean.isVerbose()) {
+            throw new Error("Verbosity was still enabled");
+        }
+        mxBean.setVerbose(true);
+        if (!mxBean.isVerbose()) {
+            throw new Error("Verbosity was still disabled");
+        }
+        // Turn off again as a double-check and also to avoid excessive logging
+        mxBean.setVerbose(false);
+        if (mxBean.isVerbose()) {
+            throw new Error("Verbosity was still enabled");
+        }
+    }
+}


### PR DESCRIPTION
A backport to jdk21u as this fixes a jck issue.

 I had to remove the namespace from LogConfiguration::StdoutLog as JDK-8299825 is not in 21.
 I also had to adapt TestVerboseClassLoading, as 'cause' is not known to the logging in 21.

Tests fail as expected, and passes with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338139](https://bugs.openjdk.org/browse/JDK-8338139) needs maintainer approval
- [x] Change requires CSR request [JDK-8338540](https://bugs.openjdk.org/browse/JDK-8338540) to be approved

### Issues
 * [JDK-8338139](https://bugs.openjdk.org/browse/JDK-8338139): {ClassLoading,Memory}MXBean::isVerbose methods are inconsistent with their setVerbose methods (**Bug** - P1 - Approved)
 * [JDK-8338540](https://bugs.openjdk.org/browse/JDK-8338540): {ClassLoading,Memory}MXBean::isVerbose methods are inconsistent with their setVerbose methods (**CSR**)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/449/head:pull/449` \
`$ git checkout pull/449`

Update a local copy of the PR: \
`$ git checkout pull/449` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 449`

View PR using the GUI difftool: \
`$ git pr show -t 449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/449.diff">https://git.openjdk.org/jdk21u/pull/449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/449#issuecomment-2321724020)