### PR TITLE
8329667: [macos] Issue with JTree related fix for JDK-8317771

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/OutlineAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/OutlineAccessibility.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,12 @@
 // This is a tree representation. See: https://developer.apple.com/documentation/appkit/nsoutlineview
 
 @interface OutlineAccessibility : ListAccessibility <NSAccessibilityOutline>
-
+{
+    NSMutableArray<id<NSAccessibilityRow>> *rowCache;
+    BOOL rowCacheValid;
+    NSMutableArray<id<NSAccessibilityRow>> *selectedRowCache;
+    BOOL selectedRowCacheValid;
+}
 @property(readonly) BOOL isTreeRootVisible;
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/OutlineAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/OutlineAccessibility.m
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,90 @@ static jmethodID sjm_isTreeRootVisible = NULL;
 - (NSString *)accessibilityLabel
 {
     return [[super accessibilityLabel] isEqualToString:@"list"] ? @"tree" : [super accessibilityLabel];
+}
+
+- (nullable NSArray<id<NSAccessibilityRow>> *)accessibilityRows
+{
+    return [self accessibilityChildren];
+}
+
+- (nullable NSArray<id<NSAccessibilityRow>> *)accessibilitySelectedRows
+{
+    return [self accessibilitySelectedChildren];
+}
+
+- (nullable  NSArray<id<NSAccessibilityRow>> *)accessibilityChildren
+{
+    if (![self isCacheValid]) {
+        NSArray *t = [super accessibilityChildren];
+        if (t != nil) {
+            rowCache = [[NSMutableArray arrayWithArray:t] retain];
+        } else {
+            rowCache = nil;
+        }
+        rowCacheValid = YES;
+    }
+    return rowCache;
+}
+
+- (nullable NSArray<id<NSAccessibilityRow>> *)accessibilitySelectedChildren
+{
+    if (!selectedRowCacheValid) {
+        NSArray *t = [super accessibilitySelectedChildren];
+        if (t != nil) {
+            selectedRowCache = [[NSMutableArray arrayWithArray:t] retain];
+        } else {
+            selectedRowCache = nil;
+        }
+        selectedRowCacheValid = YES;
+    }
+    return selectedRowCache;
+}
+
+- (BOOL)isCacheValid
+{
+    if (rowCacheValid && [[self parent] respondsToSelector:NSSelectorFromString(@"isCacheValid")]) {
+        return [[self parent] isCacheValid];
+    }
+    return rowCacheValid;
+}
+
+- (void)invalidateCache
+{
+    rowCacheValid = NO;
+}
+
+- (void)invalidateSelectionCache
+{
+    selectedRowCacheValid = NO;
+}
+
+- (void)postSelectionChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    [self invalidateSelectionCache];
+    [super postSelectionChanged];
+}
+
+- (void)postTreeNodeCollapsed
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    [self invalidateCache];
+    [super postTreeNodeCollapsed];
+}
+
+- (void)postTreeNodeExpanded
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    [self invalidateCache];
+    [super postTreeNodeExpanded];
+}
+
+- (void)postSelectedCellsChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    [self invalidateSelectionCache];
+    [super postSelectedCellsChanged];
 }
 
 @end


### PR DESCRIPTION
A clean backport to fix a regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329667](https://bugs.openjdk.org/browse/JDK-8329667) needs maintainer approval

### Issue
 * [JDK-8329667](https://bugs.openjdk.org/browse/JDK-8329667): [macos] Issue with JTree related fix for JDK-8317771 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/452/head:pull/452` \
`$ git checkout pull/452`

Update a local copy of the PR: \
`$ git checkout pull/452` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 452`

View PR using the GUI difftool: \
`$ git pr show -t 452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/452.diff">https://git.openjdk.org/jdk21u/pull/452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/452#issuecomment-2340741722)