### PR TITLE
8349729 : [AIX] jtreg tests fail to compile with qvisibility=hidden

### DIFF
--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -64,8 +64,6 @@ define SetupTestFilesCompilationBody
     TEST_LDFLAGS += -Wl,--exclude-libs,ALL
   else ifeq ($(TOOLCHAIN_TYPE), clang)
     TEST_CFLAGS += -fvisibility=hidden
-  else ifeq ($(TOOLCHAIN_TYPE), xlc)
-    TEST_CFLAGS += -qvisibility=hidden
   endif
 
   # The list to depend on starts out empty


### PR DESCRIPTION
JBS ISSUE : [JDK-8349729](https://bugs.openjdk.org/browse/JDK-8349729)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8349729](https://bugs.openjdk.org/browse/JDK-8349729) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8349729](https://bugs.openjdk.org/browse/JDK-8349729)

### Issue
 * [JDK-8349729](https://bugs.openjdk.org/browse/JDK-8349729): [21u] AIX jtreg tests fail to compile with qvisibility=hidden (**Bug** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/459/head:pull/459` \
`$ git checkout pull/459`

Update a local copy of the PR: \
`$ git checkout pull/459` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 459`

View PR using the GUI difftool: \
`$ git pr show -t 459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/459.diff">https://git.openjdk.org/jdk21u/pull/459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/459#issuecomment-2671024388)
</details>
