### PR TITLE
8352097: (tz) zone.tab update missed in 2025a backport

### DIFF
--- a/src/java.base/share/data/tzdata/zone.tab
+++ b/src/java.base/share/data/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon


### PR DESCRIPTION
The [21u backport](https://git.openjdk.org/jdk21u-dev/commit/5d21a2bcc4ba06331df52470795134d8540dd567) of the tzdata 2025a update missed an update to `zone.tab`, as this was not present in the [25u commit]( https://git.openjdk.org/jdk/commit/caa3c78f7837b1f561740184bd8f9cb671c467eb) on which it was based, due to its removal in [JDK-8166983](https://bugs.openjdk.org/browse/JDK-8166983). The change was in [the 24u commit](https://git.openjdk.org/jdk24u/commit/81252ef76899ad95197550a11c2786ccf3cf0cd2) which was applied later than the 21u one.

We should add this missing change to the existing 2025a update in 21.0.7 and consider backporting JDK-8166983 for 21.0.8.