### PR TITLE
8356328: Some C2 IR nodes miss size_of() function

### DIFF
--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -184,12 +184,12 @@ class VectorizedHashCodeNode: public Node {
 //------------------------------EncodeISOArray--------------------------------
 // encode char[] to byte[] in ISO_8859_1 or ASCII
 class EncodeISOArrayNode: public Node {
-  bool ascii;
+  bool _ascii;
  public:
   EncodeISOArrayNode(Node* control, Node* arymem, Node* s1, Node* s2, Node* c, bool ascii)
-    : Node(control, arymem, s1, s2, c), ascii(ascii) {}
+    : Node(control, arymem, s1, s2, c), _ascii(ascii) {}
 
-  bool is_ascii() { return ascii; }
+  bool is_ascii() { return _ascii; }
   virtual int Opcode() const;
   virtual bool depends_only_on_test() const { return false; }
   virtual const Type* bottom_type() const { return TypeInt::INT; }
@@ -198,6 +198,11 @@ class EncodeISOArrayNode: public Node {
   virtual uint ideal_reg() const { return Op_RegI; }
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
+  virtual uint size_of() const { return sizeof(EncodeISOArrayNode); }
+  virtual uint hash() const { return Node::hash() + _ascii; }
+  virtual bool cmp(const Node& n) const {
+    return Node::cmp(n) && _ascii == ((EncodeISOArrayNode&)n).is_ascii();
+  }
 };
 
 //-------------------------------DigitNode----------------------------------------

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -492,6 +492,7 @@ public:
   int  constant_offset() const { return ((MachConstantNode*) this)->constant_offset(); }
   // Unchecked version to avoid assertions in debug output.
   int  constant_offset_unchecked() const;
+  virtual uint size_of() const { return sizeof(MachConstantNode); }
 };
 
 //------------------------------MachUEPNode-----------------------------------
@@ -526,17 +527,15 @@ public:
 //------------------------------MachEpilogNode--------------------------------
 // Machine function Epilog Node
 class MachEpilogNode : public MachIdealNode {
+private:
+  bool _do_polling;
 public:
   MachEpilogNode(bool do_poll = false) : _do_polling(do_poll) {}
   virtual void emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const;
   virtual uint size(PhaseRegAlloc *ra_) const;
   virtual int reloc() const;
   virtual const Pipeline *pipeline() const;
-
-private:
-  bool _do_polling;
-
-public:
+  virtual uint size_of() const { return sizeof(MachEpilogNode); }
   bool do_polling() const { return _do_polling; }
 
 #ifndef PRODUCT
@@ -560,6 +559,7 @@ public:
 
   virtual int ideal_Opcode() const { return Op_Con; } // bogus; see output.cpp
   virtual const Pipeline *pipeline() const;
+  virtual uint size_of() const { return sizeof(MachNopNode); }
 #ifndef PRODUCT
   virtual const char *Name() const { return "Nop"; }
   virtual void format( PhaseRegAlloc *, outputStream *st ) const;
@@ -787,6 +787,7 @@ public:
   MachJumpNode() : MachConstantNode() {
     init_class_id(Class_MachJump);
   }
+  virtual uint size_of() const { return sizeof(MachJumpNode); }
 };
 
 //------------------------------MachGotoNode-----------------------------------
@@ -883,6 +884,7 @@ public:
     assert(verify_jvms(jvms), "jvms must match");
     set_req(_jvmadj + jvms->monoff() + idx, c);
   }
+  virtual uint size_of() const { return sizeof(MachSafePointNode); }
 };
 
 //------------------------------MachCallNode----------------------------------
@@ -997,6 +999,7 @@ public:
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;
 #endif
+  virtual uint size_of() const { return sizeof(MachCallDynamicJavaNode); }
 };
 
 //------------------------------MachCallRuntimeNode----------------------------
@@ -1030,6 +1033,7 @@ public:
   bool _reachable;
   const char* _halt_reason;
   virtual JVMState* jvms() const;
+  virtual uint size_of() const { return sizeof(MachHaltNode); }
   bool is_reachable() const {
     return _reachable;
   }

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1102,6 +1102,11 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual uint match_edge(uint idx) const;
   bool is_large() const { return _is_large; }
+  virtual uint size_of() const { return sizeof(ClearArrayNode); }
+  virtual uint hash() const { return Node::hash() + _is_large; }
+  virtual bool cmp(const Node& n) const {
+    return Node::cmp(n) && _is_large == ((ClearArrayNode&)n).is_large();
+  }
 
   // Clear the given area of an object or array.
   // The start offset must always be aligned mod BytesPerInt.

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -107,6 +107,7 @@ class Opaque3Node : public Node {
   virtual const Type* bottom_type() const { return TypeInt::INT; }
   virtual Node* Identity(PhaseGVN* phase);
   bool rtm_opt() const { return (_opt == RTM_OPT); }
+  virtual uint size_of() const { return sizeof(Opaque3Node); }
 };
 
 // Input 1 is a check that we know implicitly is always true or false
@@ -154,6 +155,7 @@ class ProfileBooleanNode : public Node {
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
   virtual const Type *bottom_type() const { return TypeInt::BOOL; }
+  virtual uint size_of() const { return sizeof(ProfileBooleanNode); }
 };
 
 #endif // SHARE_OPTO_OPAQUENODE_HPP


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9927ec0b](https://github.com/openjdk/jdk/commit/9927ec0b91775db342b2bbc1937253325c367a19) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kuai Wei on 18 May 2025 and was reviewed by Tobias Hartmann and Christian Hagedorn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8356328](https://bugs.openjdk.org/browse/JDK-8356328) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356328](https://bugs.openjdk.org/browse/JDK-8356328): Some C2 IR nodes miss size_of() function (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/462/head:pull/462` \
`$ git checkout pull/462`

Update a local copy of the PR: \
`$ git checkout pull/462` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 462`

View PR using the GUI difftool: \
`$ git pr show -t 462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/462.diff">https://git.openjdk.org/jdk21u/pull/462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/462#issuecomment-2893485282)
</details>
