### PR TITLE
8360406: [21u] Disable logic for attaching type annotations to class files until 8359336 is fixed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -131,6 +131,8 @@ public class ClassReader {
      */
     public boolean saveParameterNames;
 
+    private final boolean addTypeAnnotationsToSymbol;
+
     /**
      * The currently selected profile.
      */
@@ -296,6 +298,8 @@ public class ClassReader {
         typevars = WriteableScope.create(syms.noSymbol);
 
         lintClassfile = Lint.instance(context).isEnabled(LintCategory.CLASSFILE);
+
+        addTypeAnnotationsToSymbol = options.getBoolean("addTypeAnnotationsToSymbol", false);
 
         initAttributeReaders();
     }
@@ -2258,7 +2262,9 @@ public class ClassReader {
                 currentClassFile = classFile;
                 List<Attribute.TypeCompound> newList = deproxyTypeCompoundList(proxies);
                 sym.setTypeAttributes(newList.prependList(sym.getRawTypeAttributes()));
-                addTypeAnnotationsToSymbol(sym, newList);
+                if (addTypeAnnotationsToSymbol) {
+                    addTypeAnnotationsToSymbol(sym, newList);
+                }
             } finally {
                 currentClassFile = previousClassFile;
             }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
@@ -80,7 +80,7 @@ public class CompletionErrorOnEnclosingType {
                 new JavacTask(tb)
                         .outdir(out)
                         .classpath(out)
-                        .options("-XDrawDiagnostics")
+                        .options("-XDrawDiagnostics", "-XDaddTypeAnnotationsToSymbol=true")
                         .files(src.resolve("C.java"))
                         .run(Expect.FAIL)
                         .writeAll()

--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -33,7 +33,7 @@
  *          jdk.compiler/com.sun.tools.javac.util
  * @build JavacTestingAbstractProcessor DPrinter BasicAnnoTests
  * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests.java
- * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests
+ * @compile/process -XDaccessInternalAPI -XDaddTypeAnnotationsToSymbol=true -processor BasicAnnoTests -proc:only BasicAnnoTests
  */
 
 import java.io.PrintWriter;


### PR DESCRIPTION
This change temporarily disables the logic added by JDK-8341779 and related backports, to work around the crash reported in JDK-8359336.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8360406](https://bugs.openjdk.org/browse/JDK-8360406) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360406](https://bugs.openjdk.org/browse/JDK-8360406): [21u] Disable logic for attaching type annotations to class files until 8359336 is fixed (**Bug** - P2 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/466/head:pull/466` \
`$ git checkout pull/466`

Update a local copy of the PR: \
`$ git checkout pull/466` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 466`

View PR using the GUI difftool: \
`$ git pr show -t 466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/466.diff">https://git.openjdk.org/jdk21u/pull/466.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/466#issuecomment-3001064969)
</details>
