### PR TITLE
8367388: Tests start to fail on JDK-21 after JDK-8351907

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
@@ -64,6 +64,7 @@ public class XdgDesktopPortal {
                     : METHOD_SCREENCAST;
         }
 
+        @SuppressWarnings("removal")
         String m = AccessController.doPrivileged(
                 new GetPropertyAction(
                         "awt.robot.screenshotMethod", defaultMethod

--- a/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
@@ -29,6 +29,8 @@ import sun.awt.SunToolkit;
 import sun.awt.UNIXToolkit;
 
 import java.awt.Toolkit;
+import java.security.AccessController;
+import sun.security.action.GetPropertyAction;
 
 public class XdgDesktopPortal {
     private static final String METHOD_X11 = "x11";
@@ -62,7 +64,10 @@ public class XdgDesktopPortal {
                     : METHOD_SCREENCAST;
         }
 
-        String m = System.getProperty("awt.robot.screenshotMethod", defaultMethod);
+        String m = AccessController.doPrivileged(
+                new GetPropertyAction(
+                        "awt.robot.screenshotMethod", defaultMethod
+                ));
 
         if (!METHOD_REMOTE_DESKTOP.equals(m)
                 && !METHOD_SCREENCAST.equals(m)


### PR DESCRIPTION
After the patch for [JDK-8351907](https://bugs.openjdk.org/browse/JDK-8351907), in some cases it is no longer possible to load the XAWT toolkit under a SecurityManager in JDK 21.

The change in the mainline JDK removed the use of AccessController.doPrivileged, but in JDK 21u it is still required. Without it, access to system property (awt.robot.screenshotMethod) is blocked.

Fix: Restore use of [AccessController.doPrivileged](https://github.com/openjdk/jdk21u/commit/72d9bd69678dd54ef9e92f9c62073c0c4bf73c41#diff-2b4ac3949cd7faca02daa92815bd0e33d01f6f5b8914de2815d7cc5a864407f5L64) for property access in JDK 21u.
Verified with jdk_desktop group in both headful and headless modes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367388](https://bugs.openjdk.org/browse/JDK-8367388) needs maintainer approval

### Issue
 * [JDK-8367388](https://bugs.openjdk.org/browse/JDK-8367388): Tests start to fail on JDK-21 after JDK-8351907 (**Bug** - P2 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/469/head:pull/469` \
`$ git checkout pull/469`

Update a local copy of the PR: \
`$ git checkout pull/469` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 469`

View PR using the GUI difftool: \
`$ git pr show -t 469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/469.diff">https://git.openjdk.org/jdk21u/pull/469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/469#issuecomment-3282730129)
</details>
