### PR TITLE
8339271: giflib attribution correction

### DIFF
--- a/src/java.desktop/share/legal/giflib.md
+++ b/src/java.desktop/share/legal/giflib.md
@@ -23,8 +23,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+---------------------------------
+The below applies to the following file(s):
+giflib/openbsd-reallocarray.c
 
-tree/README
+Copyright (C) 2008 Otto Moerbeek <otto@drijf.net>
+SPDX-License-Identifier: MIT
+
 
 == Authors ==
 
@@ -37,14 +42,5 @@ former maintainer
 
 Eric Raymond <esr[AT]snark.thyrsus.com>
 current as well as long time former maintainer of giflib code
-
-There have been many other contributors; see the attributions in the
-version-control history to learn more.
-
-
-tree/openbsd-reallocarray.c
-
-Copyright (C) 2008 Otto Moerbeek <otto@drijf.net>
-SPDX-License-Identifier: MIT
 
 ```


### PR DESCRIPTION
I backport this as licenses should be as correct as possible.
Also needed to make a possible backport of [JDK-8379256](https://bugs.openjdk.org/browse/JDK-8379256) ff clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339271](https://bugs.openjdk.org/browse/JDK-8339271) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8339271: giflib attribution correction`

### Issue
 * [JDK-8339271](https://bugs.openjdk.org/browse/JDK-8339271): giflib attribution correction (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/490/head:pull/490` \
`$ git checkout pull/490`

Update a local copy of the PR: \
`$ git checkout pull/490` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 490`

View PR using the GUI difftool: \
`$ git pr show -t 490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/490.diff">https://git.openjdk.org/jdk21u/pull/490.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/490#issuecomment-4065847635)
</details>
