### PR TITLE
8380078: Update GIFlib to 6.1.2

### DIFF
--- a/src/java.desktop/share/legal/giflib.md
+++ b/src/java.desktop/share/legal/giflib.md
@@ -1,4 +1,4 @@
-## GIFLIB v6.1.1
+## GIFLIB v6.1.2
 
 ### GIFLIB License
 ```

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define GIFLIB_MAJOR 6
 #define GIFLIB_MINOR 1
-#define GIFLIB_RELEASE 1
+#define GIFLIB_RELEASE 2
 
 #define GIF_ERROR 0
 #define GIF_OK 1

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
@@ -373,6 +373,14 @@ SavedImage *GifMakeSavedImage(GifFileType *GifFile,
                          * aliasing problems.
                          */
 
+                        /* Null out aliased pointers before any allocations
+                         * so that FreeLastSavedImage won't free CopyFrom's
+                         * data if an allocation fails partway through. */
+                        sp->ImageDesc.ColorMap = NULL;
+                        sp->RasterBits = NULL;
+                        sp->ExtensionBlocks = NULL;
+                        sp->ExtensionBlockCount = 0;
+
                         /* first, the local color map */
                         if (CopyFrom->ImageDesc.ColorMap != NULL) {
                                 sp->ImageDesc.ColorMap = GifMakeMapObject(


### PR DESCRIPTION
I would like to backport this to jdk21u.

Testing sun.awt.image, javax.imageio and java.awt.SplashScreen passed.
SAP nightly testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8380078](https://bugs.openjdk.org/browse/JDK-8380078) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380078](https://bugs.openjdk.org/browse/JDK-8380078): Update GIFlib to 6.1.2 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/493.diff">https://git.openjdk.org/jdk21u/pull/493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/493#issuecomment-4096211456)
</details>
