### PR TITLE
8384486: NTLM tests fail on Windows 11 and Windows Server 2025

### DIFF
--- a/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
+++ b/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,9 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8270290
+ * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm NTLMHeadTest SERVER
  * @run main/othervm NTLMHeadTest PROXY
@@ -46,6 +47,17 @@
  *      (to not block on socket read) because HEAD is sent to server and
  *      NTLMSSP_CHALLENGE response includes Content-Length, but does not
  *      include the body.
+ */
+
+/*
+ * @test id=windows
+ * @bug 8270290
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
+ * @library /test/lib
+ * @run main/othervm NTLMHeadTest SERVER
+ * @run main/othervm NTLMHeadTest PROXY
+ * @run main/othervm NTLMHeadTest TUNNEL
  */
 
 import java.net.*;

--- a/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
+++ b/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
@@ -26,7 +26,8 @@
  * @bug 8225425
  * @summary Verifies that transparent NTLM (on Windows) is not used by default,
  *          and is used only when the relevant property is set.
- * @requires os.family == "windows"
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
  * @library /test/lib
  * @run testng/othervm
  *      -Dtest.auth.succeed=false


### PR DESCRIPTION
Bringing this clean test-only fix to jdk21u will assure clean tests during rampdown.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8384486](https://bugs.openjdk.org/browse/JDK-8384486) needs maintainer approval

### Issue
 * [JDK-8384486](https://bugs.openjdk.org/browse/JDK-8384486): NTLM tests fail on Windows 11 and Windows Server 2025 (**Bug** - P4 - Approved)


### Reviewers without OpenJDK IDs
 * @raneashay (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/495/head:pull/495` \
`$ git checkout pull/495`

Update a local copy of the PR: \
`$ git checkout pull/495` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 495`

View PR using the GUI difftool: \
`$ git pr show -t 495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/495.diff">https://git.openjdk.org/jdk21u/pull/495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/495#issuecomment-4646905125)
</details>
