### PR TITLE
8333743: Change .jcheck/conf branches property to match valid branches

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -9,7 +9,7 @@ warning=issuestitle,binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
-branches=
+branches=.*
 
 [census]
 version=0


### PR DESCRIPTION
I would like to setup the Aug update properly.
This should be fine as it does not affect the product.
This way it's fixed for a possible Sep update.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8333743](https://bugs.openjdk.org/browse/JDK-8333743): Change .jcheck/conf branches property to match valid branches (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/499/head:pull/499` \
`$ git checkout pull/499`

Update a local copy of the PR: \
`$ git checkout pull/499` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 499`

View PR using the GUI difftool: \
`$ git pr show -t 499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/499.diff">https://git.openjdk.org/jdk21u/pull/499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/499#issuecomment-5070071970)
</details>
