### PR TITLE
8333743: Change .jcheck/conf branches property to match valid branches

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -9,7 +9,7 @@ warning=issuestitle,binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
-branches=
+branches=.*
 
 [census]
 version=0


### PR DESCRIPTION
A hand crafted change, as the one generaetd by /backport jdk21u:21.0.12.1 is not handled properly by skara.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with updated jcheck configuration in pull request)

### Issue
 * [JDK-8333743](https://bugs.openjdk.org/browse/JDK-8333743): Change .jcheck/conf branches property to match valid branches (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/500.diff">https://git.openjdk.org/jdk21u/pull/500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/500#issuecomment-5090913868)
</details>
