### PR TITLE
Backport d8e2a54cfee10f1f4f4c7e28104f5880bddce8e8

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
@@ -36,6 +36,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=dfsonly
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack dfsonly
@@ -45,6 +46,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=bfsdfs
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack bfsdfs


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [d8e2a54c](https://github.com/openjdk/jdk/commit/d8e2a54cfee10f1f4f4c7e28104f5880bddce8e8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Markus Grönlund on 28 Apr 2026 and was reviewed by Erik Gahlin.

I am backporting this to prevent the test from failing when running with an unsupported GC passed to jtreg via -vmoptions.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
