### PR TITLE
8390380: Cherry-pick metazone changes from CLDR to support tzdata2026c for JDK update releases

### DIFF
--- a/make/data/cldr/common/supplemental/metaZones.xml
+++ b/make/data/cldr/common/supplemental/metaZones.xml
@@ -57,6 +57,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone to="1984-03-16 00:00" mzone="Europe_Western"/>
 				<usesMetazone to="1985-12-31 23:00" from="1984-03-16 00:00" mzone="Europe_Central"/>
 				<usesMetazone to="2018-10-28 02:00" from="1985-12-31 23:00" mzone="Europe_Western"/>
+				<usesMetazone from="2026-09-20 01:00" mzone="Europe_Western"/>
 			</timezone>
 			<timezone type="Africa/Ceuta">
 				<usesMetazone to="1984-03-16 00:00" mzone="Europe_Western"/>
@@ -80,6 +81,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<timezone type="Africa/El_Aaiun">
 				<usesMetazone to="1976-04-14 01:00" mzone="Africa_FarWestern"/>
 				<usesMetazone to="2018-10-28 02:00" from="1976-04-14 01:00" mzone="Europe_Western"/>
+				<usesMetazone from="2026-09-20 01:00" mzone="Europe_Western"/>
 			</timezone>
 			<timezone type="Africa/Freetown">
 				<usesMetazone mzone="GMT"/>
@@ -381,7 +383,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone mzone="Atlantic"/>
 			</timezone>
 			<timezone type="America/Edmonton">
-				<usesMetazone mzone="America_Mountain"/>
+				<usesMetazone mzone="America_Mountain" stdOffset="-07" dstOffset="-06"/>
 			</timezone>
 			<timezone type="America/Eirunepe">
 				<usesMetazone to="2008-06-24 05:00" mzone="Acre"/>
@@ -760,7 +762,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Yellowknife">
-				<usesMetazone mzone="America_Mountain"/>
+				<usesMetazone mzone="America_Mountain" stdOffset="-07" dstOffset="-06"/>
 			</timezone>
 			<timezone type="Antarctica/Casey">
 				<usesMetazone to="2009-10-17 18:00" mzone="Australia_Western"/>

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -24,7 +24,7 @@
  /*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279
- *      8381379 8390388
+ *      8381379 8390388 8390380
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run junit/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -190,7 +190,11 @@ public class TimeZoneNamesTest {
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time"),
             Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time"),
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time")
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
+            Arguments.of(ZonedDateTime.of(2026, 1, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 7, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time"),
+            Arguments.of(ZonedDateTime.of(2026, 1, 5, 0, 0, 0, 0, ZoneId.of("America/Yellowknife")), "Mountain Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 7, 5, 0, 0, 0, 0, ZoneId.of("America/Yellowknife")), "Mountain Daylight Time")
         );
     }
 


### PR DESCRIPTION
Backporting from https://github.com/openjdk/jdk25u-dev/commit/cc021f82bbb57b16cf8b42f60e6a501e4630eecb

This is the second change in the JDK 21 tzdata2026c stack and depends on https://github.com/openjdk/jdk21u/pull/503. It imports the selective CLDR metazone updates needed for Morocco and Alberta.

The backport was not clean because JDK 21 uses CLDR 43.0. 

That data still has a standalone `America/Yellowknife` metazone entry, while the newer CLDR data used by JDK 25 no longer does. I kept the JDK 21 entry and gave it the same explicit `-07` standard and `-06` daylight offsets as Edmonton, then added matching winter and summer test cases. 

The `TimeZoneNamesTest.java` conflict was resolved by keeping JDK 21's existing bug IDs and CLDR-provider configuration.

tzdata2026c chain:
#504
#505
#506

#### Testing
* `make images`
* `make run-test TEST="test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390380](https://bugs.openjdk.org/browse/JDK-8390380) needs maintainer approval

### Issue
 * [JDK-8390380](https://bugs.openjdk.org/browse/JDK-8390380): Cherry-pick metazone changes from CLDR to support tzdata2026c for JDK update releases (**Bug** - P3 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/504/head:pull/504` \
`$ git checkout pull/504`

Update a local copy of the PR: \
`$ git checkout pull/504` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 504`

View PR using the GUI difftool: \
`$ git pr show -t 504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/504.diff">https://git.openjdk.org/jdk21u/pull/504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/504#issuecomment-5543950815)
</details>
