### PR TITLE
8392072: Follow-on fix for Improve certification checking

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/DNSName.java
+++ b/src/java.base/share/classes/sun/security/x509/DNSName.java
@@ -229,11 +229,13 @@ public class DNSName implements GeneralNameInterface {
      * order zero bit.
      *
      * @param inputName to be checked for being constrained
+     * @param matchWildcard whether to match a wildcard in inputName
      * @return constraint type above
      * @throws UnsupportedOperationException if name is not exact match, but narrowing and widening are
      *          not supported for this name type.
      */
-    public int constrains(GeneralNameInterface inputName) throws UnsupportedOperationException {
+    public int constrains(GeneralNameInterface inputName, boolean matchWildcard)
+            throws UnsupportedOperationException {
         int constraintType;
         if (inputName == null)
             constraintType = NAME_DIFF_TYPE;
@@ -244,7 +246,9 @@ public class DNSName implements GeneralNameInterface {
                 (((DNSName)inputName).getName()).toLowerCase(Locale.ENGLISH);
             String thisName = name.toLowerCase(Locale.ENGLISH);
 
-            if (HOSTNAME_CHECKER.isMatched(thisName, inName, false))
+            if (inName.equals(thisName) || (matchWildcard
+                    && inName.contains("*")
+                    && HOSTNAME_CHECKER.isMatched(thisName, inName, false)))
                 constraintType = NAME_MATCH;
             else if (thisName.endsWith(inName)) {
                 int inNdx = thisName.lastIndexOf(inName);
@@ -263,6 +267,10 @@ public class DNSName implements GeneralNameInterface {
             }
         }
         return constraintType;
+    }
+
+    public int constrains(GeneralNameInterface inputName) {
+        return constrains(inputName, false);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -506,9 +506,15 @@ public class NameConstraintsExtension extends Extension
                 if (exName == null)
                     continue;
 
+                // Match a wildcard in DNSName only against the excluded subtree
+                int matchResult =
+                        exName.getType() == GeneralNameInterface.NAME_DNS
+                                ? ((DNSName) exName).constrains(name, true)
+                                : exName.constrains(name);
+
                 // if name matches or narrows any excluded subtree,
                 // return false
-                switch (exName.constrains(name)) {
+                switch (matchResult) {
                 case GeneralNameInterface.NAME_DIFF_TYPE:
                 case GeneralNameInterface.NAME_WIDENS: // name widens excluded
                 case GeneralNameInterface.NAME_SAME_TYPE:


### PR DESCRIPTION
This fixes a regression in 21.0.12.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8392072](https://bugs.openjdk.org/browse/JDK-8392072) needs maintainer approval

### Issue
 * [JDK-8392072](https://bugs.openjdk.org/browse/JDK-8392072): Follow-on fix for Improve certification checking (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u.git pull/507/head:pull/507` \
`$ git checkout pull/507`

Update a local copy of the PR: \
`$ git checkout pull/507` \
`$ git pull https://git.openjdk.org/jdk21u.git pull/507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 507`

View PR using the GUI difftool: \
`$ git pr show -t 507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u/pull/507.diff">https://git.openjdk.org/jdk21u/pull/507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u/pull/507#issuecomment-5645198451)
</details>
